### PR TITLE
Enable support for subgroups

### DIFF
--- a/gitlabform/configuration/projects_and_groups.py
+++ b/gitlabform/configuration/projects_and_groups.py
@@ -28,7 +28,7 @@ class ConfigurationProjectsAndGroups(ConfigurationCore):
 
         logging.debug("Project config: %s" % project_config)
 
-        group, _ = group_and_project.split('/')
+        group, _ = group_and_project.rsplit('/', 1)
         try:
             group_config = self.get_config_for_group(group)
         except ConfigNotFoundException:


### PR DESCRIPTION
PROBLEM
When setting a group configuration against a project that is in a subgroup (e.g. it has a slash in the name), GitLabForm fails with an error:

```
λ python C:\Users\x\AppData\Local\Programs\Python\Python36\Scripts\gitlabform ALL_DEFINED
>>> Processing ALL groups and projects defined in config
*** # of groups to process: 1
*** # of projects to process: 31
* [1/31] Processing: group/subgroup/project1
Traceback (most recent call last):
  File "C:\Users\x\AppData\Local\Programs\Python\Python36\Scripts\gitlabform", line 6, in <module>
    GitLabForm().main()
  File "C:\Users\x\AppData\Local\Programs\Python\Python36\lib\site-packages\gitlabform\gitlabform\core.py", line 136, in main
    self.process_all(projects_and_groups)
  File "C:\Users\x\AppData\Local\Programs\Python\Python36\lib\site-packages\gitlabform\gitlabform\core.py", line 201, in process_all
    configuration = self.c.get_effective_config_for_project(project_and_group)
  File "C:\Users\x\AppData\Local\Programs\Python\Python36\lib\site-packages\gitlabform\configuration\projects_and_groups.py", line 31, in get_effective_config_for_project
    group, _ = group_and_project.split('/')
ValueError: too many values to unpack (expected 2)
```

SOLUTION
Use rsplit instead of split to split the group_and_project string on the last delimiter only.