### PR TITLE
setup.py: Fix naming of tests_require keyword

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='gitlabform',
             'requests>=2.20.0',
             'pyyaml==3.13',
       ],
-      tests_requires=[
+      tests_require=[
             'pytest',
       ],
       setup_requires=[


### PR DESCRIPTION
tests_require instead of tests_requires See https://setuptools.readthedocs.io/en/latest/setuptools.html