### PR TITLE
Fix app crashing on missing config sections

### DIFF
--- a/gitlabform/configuration/core.py
+++ b/gitlabform/configuration/core.py
@@ -57,7 +57,7 @@ class ConfigurationCore:
             for token in tokens:
                 current = current[token]
         except:
-            if default:
+            if default is not None:
                 return default
             else:
                 raise KeyNotFoundException

--- a/gitlabform/configuration/projects_and_groups.py
+++ b/gitlabform/configuration/projects_and_groups.py
@@ -12,7 +12,7 @@ class ConfigurationProjectsAndGroups(ConfigurationCore):
         :return: sorted list of projects with configs
         """
         try:
-            return sorted(self.get("project_settings").keys())
+            return sorted(self.get("project_settings", {}).keys())
         except KeyNotFoundException:
             raise ConfigNotFoundException
 
@@ -79,7 +79,7 @@ class ConfigurationProjectsAndGroups(ConfigurationCore):
         :return: sorted list of groups with configs
         """
         try:
-            return sorted(self.get("group_settings").keys())
+            return sorted(self.get("group_settings", default={}).keys())
         except KeyNotFoundException:
             raise ConfigNotFoundException
 


### PR DESCRIPTION
When some sections are missing in config then app crashes with
ConfigNotFoundException exception.

But it should be allowed to skip groups or project settings if they
should be kept unmanaged.

This change fixes this behaviour.