### PR TITLE
recursively find groups / subgroups

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -97,7 +97,9 @@ group_settings:
         - user1
         - user2
       approver_groups:
-        - my_group1
+        - my_group
+        - my_group1/subgroup
+        - my_group2/subgroup/subsubgroup
 
     # keys names are branches names and values are as parameters described at
     # https://docs.gitlab.com/ee/api/branches.html#protect-repository-branch

--- a/gitlabform/gitlab/core.py
+++ b/gitlabform/gitlab/core.py
@@ -74,6 +74,7 @@ class GitLabCore:
                 raise NotFoundException("No groups found when searching for group path '%s'" % path)
 
             for group in groups:
+                if group['path'] == path:
                     return group['id']
 
             raise NotFoundException("None of the found group(s) when searching for group path '%s'"


### PR DESCRIPTION
This PR adds recursive lookup functionality to find a group, or sub group id. We needed this functionality so that we could correctly assign merge request approvers that are in a subgroup.

Covers the following group structures:
- `group`
- `group/[subgroup/...]` (recursively)

This maintains existing functionality, while allowing to find any sub group, no matter how deep it is in the path. Probably not the most performant, as it is still relying on the `groups?search=...` api initially.