### PR TITLE
Add jinja2 filesystem loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ MANIFEST
 # prevent accidental pushing own config to github
 config-develop.yml
 /config
+
+# vscode
+.vscode/

--- a/config.yml
+++ b/config.yml
@@ -186,6 +186,14 @@ group_settings:
         # You can provide file contents with external file too. Both absolute and relative paths are supported.
         # Relative paths are interpreted as relative to `config.yml` file location.
         file: some-file.txt
+      "rendered-file":
+        overwrite: true
+        branches: all
+        # jinja templating in gitlabform is supported by FileSystemLoader, so templates could also render each other using for example {% extends 'relative/path/to/other.jinja2' %}
+        file: some-file.txt.jinja2
+        template: yes
+        jinja_env:
+          foo: 'bar'
       "file-using-templating":
         overwrite: true
         branches: all

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def convert_markdown_to_rst(file):
 
 
 setup(name='gitlabform',
-      version='1.5.0',
+      version='1.5.1',
       description='Easy configuration as code tool for GitLab using config in plain YAML',
       long_description=convert_markdown_to_rst('README.md'),
       url='https://github.com/egnyte/gitlabform',


### PR DESCRIPTION
This pull request introduces support for jinja2 filesystems what allows gitlabform to read files within repository and use them as a templates. Beside this I have also added more verbosity to error message when user forgets to provide his gitlab access token what could be treated as a bugfix.