### PR TITLE
Adding python37 and python38 to tests and package information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ language: python
 python:
 - '3.5'
 - '3.6'
+- '3.7'
+- '3.8'
 
 # docker
 env:
-- alpine_version=alpine3.9 debian_version=stretch
+- alpine_version=alpine3.10 debian_version=buster
 
 services:
 - docker

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-log_cli=true
-log_level=DEBUG
+filterwarnings =
+    ignore::DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from setuptools import setup, find_packages
-from pypandoc import convert
+from pypandoc import convert_file
 
 def convert_markdown_to_rst(file):
-      return convert(file, 'rst')
+      return convert_file(file, 'rst')
 
 
 setup(name='gitlabform',
@@ -16,6 +16,7 @@ setup(name='gitlabform',
             "Programming Language :: Python :: 3.5",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
             "Development Status :: 4 - Beta",
             "Intended Audience :: Information Technology",
             "Intended Audience :: System Administrators",


### PR DESCRIPTION
Added python37/python38 to tests and python38 to supported versions.
Removing debug from pytests and setting ignore on deprecation warnings which usually come from third party packages.