### PR TITLE
Add new Merge Requests Approvers API support *with limitation to 1 user and 1 group*

### DIFF
--- a/gitlabform/gitlab/projects.py
+++ b/gitlabform/gitlab/projects.py
@@ -189,10 +189,10 @@ class GitLabProjects(GitLabCore):
             user_ids.append(self._get_user_id(approver_name))
         group_ids = []
         for group_path in approver_groups:
-            group_ids.append(self._get_group_id(group_path))
+            group_ids.append(int(self._get_group_id(group_path)))
 
         data = {
-            'id': pid,
+            'id': int(pid),
             'name': name,
             'approvals_required': approvals_required,
             'user_ids': user_ids,

--- a/gitlabform/gitlab/projects.py
+++ b/gitlabform/gitlab/projects.py
@@ -124,14 +124,14 @@ class GitLabProjects(GitLabCore):
         data = {**data, **data_required}
         self._make_requests_to_api("projects/%s/hooks", project_and_group_name, 'POST', data, expected_codes=201)
 
-    def post_approvals(self, project_and_group_name, data):
+    def post_approvals_settings(self, project_and_group_name, data):
         # for this endpoint GitLab still actually wants pid, not "group/project"...
         pid = self._get_project_id(project_and_group_name)
         data_required = {'id': pid}
         data = {**data, **data_required}
         self._make_requests_to_api("projects/%s/approvals", pid, 'POST', data, expected_codes=201)
 
-    def get_approvers(self, project_and_group_name):
+    def get_approvals_settings(self, project_and_group_name):
         pid = self._get_project_id(project_and_group_name)
         return self._make_requests_to_api("projects/%s/approvals", pid)
 

--- a/gitlabform/gitlabform/core.py
+++ b/gitlabform/gitlabform/core.py
@@ -308,6 +308,15 @@ class GitLabFormCore(object):
         if approvers is not None or approver_groups is not None \
                 and approvals and 'approvals_before_merge' in approvals:
 
+            # because of https://gitlab.com/gitlab-org/gitlab/issues/198770 we cannot set more than 1 user
+            # or 1 group as approvers, sorry
+            if (approvers and len(approvers) > 1) or (approver_groups and len(approver_groups) > 1):
+                logging.fatal("Because of https://gitlab.com/gitlab-org/gitlab/issues/198770 you cannot set more than "
+                              "1 user or 1 group as approvers, sorry."
+                              "Please see https://github.com/egnyte/gitlabform/issues/68#issuecomment-581003703 "
+                              "for information about a possible workaround for this limitation.")
+                sys.exit(4)
+
             # in pre-12.3 API approvers (users and groups) were configured under the same endpoint as approvals settings
             approvals_settings = self.gl.get_approvals_settings(project_and_group)
             if 'approvers' in approvals_settings or 'approver_groups' in approvals_settings:

--- a/gitlabform/gitlabform/core.py
+++ b/gitlabform/gitlabform/core.py
@@ -304,14 +304,41 @@ class GitLabFormCore(object):
 
         approvers = configuration.get('merge_requests|approvers')
         approver_groups = configuration.get('merge_requests|approver_groups')
-        # checking if is not None allows configs with empty array to work
-        if approvers is not None or approver_groups is not None:
+        # checking if "is not None" allows configs with empty array to work
+        if approvers is not None or approver_groups is not None \
+                and approvals and 'approvals_before_merge' in approvals:
+
+            # in pre-12.3 API approvers (users and groups) were configured under the same endpoint as approvals settings
+            approvals_settings = self.gl.get_approvals_settings(project_and_group)
+            if 'approvers' in approvals_settings or 'approver_groups' in approvals_settings:
+                logging.debug("Deleting legacy approvers setup")
+                self.gl.delete_legacy_approvers(project_and_group)
+
+            approval_rule_name = 'Approvers (configured using GitLabForm)'
+
+            # is a rule already configured and just needs updating?
+            approval_rule_id = None
+            rules = self.gl.get_approvals_rules(project_and_group)
+            for rule in rules:
+                if rule['name'] == approval_rule_name:
+                    approval_rule_id = rule['id']
+                    break
+
             if not approvers:
                 approvers = []
             if not approver_groups:
                 approver_groups = []
-            logging.info("Setting approvers to users %s and groups %s" % (approvers, approver_groups))
-            self.gl.put_approvers(project_and_group, approvers, approver_groups)
+
+            if approval_rule_id:
+                # the rule exists, needs an update
+                logging.info("Updating approvers rule to users %s and groups %s" % (approvers, approver_groups))
+                self.gl.update_approval_rule(project_and_group, approval_rule_id, approval_rule_name,
+                                             approvals['approvals_before_merge'], approvers, approver_groups)
+            else:
+                # the rule does not exist yet, let's create it
+                logging.info("Creating approvers rule to users %s and groups %s" % (approvers, approver_groups))
+                self.gl.create_approval_rule(project_and_group, approval_rule_name,
+                                             approvals['approvals_before_merge'], approvers, approver_groups)
 
     @if_in_config_and_not_skipped
     @configuration_to_safe_dict

--- a/gitlabform/gitlabform/core.py
+++ b/gitlabform/gitlabform/core.py
@@ -300,7 +300,7 @@ class GitLabFormCore(object):
         approvals = configuration.get('merge_requests|approvals')
         if approvals:
             logging.info("Setting approvals settings: %s", approvals)
-            self.gl.post_approvals(project_and_group, approvals)
+            self.gl.post_approvals_settings(project_and_group, approvals)
 
         approvers = configuration.get('merge_requests|approvers')
         approver_groups = configuration.get('merge_requests|approver_groups')

--- a/gitlabform/gitlabform/test/test_merge_request_approvers.py
+++ b/gitlabform/gitlabform/test/test_merge_request_approvers.py
@@ -18,7 +18,7 @@ GROUP_WITH_USER4 = 'gitlabform_tests_group_with_user4'
 DEVELOPER_ACCESS = 30
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def gitlab(request):
 
     create_group(GROUP_NAME)
@@ -38,15 +38,123 @@ def gitlab(request):
     gl = get_gitlab()
 
     def fin():
-        # the only thing needed to clean up after below tests is disabling merge requests for the project
-        # completely - this should reset project's MR approvers and approver groups lists
+        # remove all the approval rules and disable approvals in the project
+        rules = gl.get_approvals_rules(GROUP_AND_PROJECT_NAME)
+        for rule in rules:
+            gl.delete_approvals_rule(GROUP_AND_PROJECT_NAME, rule['id'])
         gl.put_project_settings(GROUP_AND_PROJECT_NAME, {'merge_requests_access_level': 'disabled'})
 
     request.addfinalizer(fin)
     return gl  # provide fixture value
 
 
-config__approvers_only_users = """
+config__approvers_single_user = """
+gitlab:
+  api_version: 4
+
+project_settings:
+  gitlabform_tests_group/merge_requests_project:
+    project_settings:
+      merge_requests_access_level: "enabled"
+    merge_requests:
+      approvals:
+        approvals_before_merge: 1
+        reset_approvals_on_push: true
+        disable_overriding_approvers_per_merge_request: true
+      approvers:
+        - merge_requests_user1
+"""
+
+config__approvers_single_user_change = """
+gitlab:
+  api_version: 4
+
+project_settings:
+  gitlabform_tests_group/merge_requests_project:
+    project_settings:
+      merge_requests_access_level: "enabled"
+    merge_requests:
+      approvals:
+        approvals_before_merge: 1
+        reset_approvals_on_push: true
+        disable_overriding_approvers_per_merge_request: true
+      approvers:
+        - merge_requests_user2
+"""
+
+config__approvers_single_group = """
+gitlab:
+  api_version: 4
+
+project_settings:
+  gitlabform_tests_group/merge_requests_project:
+    project_settings:
+      merge_requests_access_level: "enabled"
+    merge_requests:
+      approvals:
+        approvals_before_merge: 1
+        reset_approvals_on_push: true
+        disable_overriding_approvers_per_merge_request: true
+      approver_groups:
+        - gitlabform_tests_group_with_user1_and_user2
+"""
+
+config__approvers_single_group_change = """
+gitlab:
+  api_version: 4
+
+project_settings:
+  gitlabform_tests_group/merge_requests_project:
+    project_settings:
+      merge_requests_access_level: "enabled"
+    merge_requests:
+      approvals:
+        approvals_before_merge: 1
+        reset_approvals_on_push: true
+        disable_overriding_approvers_per_merge_request: true
+      approver_groups:
+        - gitlabform_tests_group_with_user4
+"""
+
+config__approvers_single_user_and_single_group = """
+gitlab:
+  api_version: 4
+
+project_settings:
+  gitlabform_tests_group/merge_requests_project:
+    project_settings:
+      merge_requests_access_level: "enabled"
+    merge_requests:
+      approvals:
+        approvals_before_merge: 1
+        reset_approvals_on_push: true
+        disable_overriding_approvers_per_merge_request: true
+      approvers:
+        - merge_requests_user1
+      approver_groups:
+        - gitlabform_tests_group_with_user4
+"""
+
+config__approvers_single_user_and_single_group_change = """
+gitlab:
+  api_version: 4
+
+project_settings:
+  gitlabform_tests_group/merge_requests_project:
+    project_settings:
+      merge_requests_access_level: "enabled"
+    merge_requests:
+      approvals:
+        approvals_before_merge: 1
+        reset_approvals_on_push: true
+        disable_overriding_approvers_per_merge_request: true
+      approvers:
+        - merge_requests_user2
+      approver_groups:
+        - gitlabform_tests_group_with_user1_and_user2
+"""
+
+config__approvers_more_than_one_user = """
 gitlab:
   api_version: 4
 
@@ -64,109 +172,100 @@ project_settings:
         - merge_requests_user2
 """
 
-config__approvers_only_users_change = """
-gitlab:
-  api_version: 4
-
-project_settings:
-  gitlabform_tests_group/merge_requests_project:
-    project_settings:
-      merge_requests_access_level: "enabled"
-    merge_requests:
-      approvals:
-        approvals_before_merge: 1
-        reset_approvals_on_push: true
-        disable_overriding_approvers_per_merge_request: true
-      approvers:
-        - merge_requests_user1
-"""
-
-config__approvers_only_groups = """
-gitlab:
-  api_version: 4
-
-project_settings:
-  gitlabform_tests_group/merge_requests_project:
-    project_settings:
-      merge_requests_access_level: "enabled"
-    merge_requests:
-      approvals:
-        approvals_before_merge: 1
-        reset_approvals_on_push: true
-        disable_overriding_approvers_per_merge_request: true
-      approver_groups:
-        - gitlabform_tests_group_with_user1_and_user2
-        - gitlabform_tests_group_with_user3
-"""
-
-config__approvers_only_groups_change = """
-gitlab:
-  api_version: 4
-
-project_settings:
-  gitlabform_tests_group/merge_requests_project:
-    project_settings:
-      merge_requests_access_level: "enabled"
-    merge_requests:
-      approvals:
-        approvals_before_merge: 1
-        reset_approvals_on_push: true
-        disable_overriding_approvers_per_merge_request: true
-      approver_groups:
-        - gitlabform_tests_group_with_user4
-"""
-
 
 class TestMergeRequestApprovers:
 
-    def test__if_it_works__only_users(self, gitlab):
-        gf = GitLabForm(config_string=config__approvers_only_users, project_or_group=GROUP_AND_PROJECT_NAME)
-        gf.main()
-
-        rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
-        assert len(rules) == 1
-        assert len(rules[0]['users']) == 2
-        assert len(rules[0]['groups']) == 0
-
-    def test__if_change_works__only_users(self, gitlab):
-        gf = GitLabForm(config_string=config__approvers_only_users, project_or_group=GROUP_AND_PROJECT_NAME)
-        gf.main()
-
-        rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
-        assert len(rules) == 1
-        assert len(rules[0]['users']) == 2
-        assert len(rules[0]['groups']) == 0
-
-        gf = GitLabForm(config_string=config__approvers_only_users_change, project_or_group=GROUP_AND_PROJECT_NAME)
+    def test__if_it_works__single_user(self, gitlab):
+        gf = GitLabForm(config_string=config__approvers_single_user, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
         rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
         assert len(rules) == 1
         assert len(rules[0]['users']) == 1
+        assert rules[0]['users'][0]['username'] == 'merge_requests_user1'
         assert len(rules[0]['groups']) == 0
 
-    def test__if_it_works__only_groups(self, gitlab):
-        gf = GitLabForm(config_string=config__approvers_only_groups, project_or_group=GROUP_AND_PROJECT_NAME)
+    def test__if_change_works__only_users(self, gitlab):
+        gf = GitLabForm(config_string=config__approvers_single_user, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
         rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
         assert len(rules) == 1
-        assert len(rules[0]['groups']) == 2
-        assert len(rules[0]['users']) == 0
+        assert len(rules[0]['users']) == 1
+        assert rules[0]['users'][0]['username'] == 'merge_requests_user1'
+        assert len(rules[0]['groups']) == 0
 
-    def test__if_change_works__only_groups(self, gitlab):
-        gf = GitLabForm(config_string=config__approvers_only_groups, project_or_group=GROUP_AND_PROJECT_NAME)
+        gf = GitLabForm(config_string=config__approvers_single_user_change, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
         rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
         assert len(rules) == 1
-        assert len(rules[0]['groups']) == 2
-        assert len(rules[0]['users']) == 0
+        assert len(rules[0]['users']) == 1
+        assert rules[0]['users'][0]['username'] == 'merge_requests_user2'
+        assert len(rules[0]['groups']) == 0
 
-        gf = GitLabForm(config_string=config__approvers_only_groups_change, project_or_group=GROUP_AND_PROJECT_NAME)
+    def test__if_it_works__single_group(self, gitlab):
+        gf = GitLabForm(config_string=config__approvers_single_group, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
         rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
         assert len(rules) == 1
         assert len(rules[0]['groups']) == 1
+        assert rules[0]['groups'][0]['name'] == 'gitlabform_tests_group_with_user1_and_user2'
         assert len(rules[0]['users']) == 0
+
+    def test__if_change_works__single_group_change(self, gitlab):
+        gf = GitLabForm(config_string=config__approvers_single_group, project_or_group=GROUP_AND_PROJECT_NAME)
+        gf.main()
+
+        rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
+        assert len(rules) == 1
+        assert len(rules[0]['groups']) == 1
+        assert rules[0]['groups'][0]['name'] == 'gitlabform_tests_group_with_user1_and_user2'
+        assert len(rules[0]['users']) == 0
+
+        gf = GitLabForm(config_string=config__approvers_single_group_change, project_or_group=GROUP_AND_PROJECT_NAME)
+        gf.main()
+
+        rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
+        assert len(rules) == 1
+        assert len(rules[0]['groups']) == 1
+        assert rules[0]['groups'][0]['name'] == 'gitlabform_tests_group_with_user4'
+        assert len(rules[0]['users']) == 0
+
+    def test__if_it_works__single_user_and_single_group(self, gitlab):
+        gf = GitLabForm(config_string=config__approvers_single_user_and_single_group, project_or_group=GROUP_AND_PROJECT_NAME)
+        gf.main()
+
+        rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
+        assert len(rules) == 1
+        assert len(rules[0]['users']) == 1
+        assert rules[0]['users'][0]['username'] == 'merge_requests_user1'
+        assert len(rules[0]['groups']) == 1
+        assert rules[0]['groups'][0]['name'] == 'gitlabform_tests_group_with_user4'
+
+    def test__if_change_works__single_user_and_single_group_change(self, gitlab):
+        gf = GitLabForm(config_string=config__approvers_single_user_and_single_group, project_or_group=GROUP_AND_PROJECT_NAME)
+        gf.main()
+
+        rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
+        assert len(rules) == 1
+        assert len(rules[0]['users']) == 1
+        assert rules[0]['users'][0]['username'] == 'merge_requests_user1'
+        assert len(rules[0]['groups']) == 1
+        assert rules[0]['groups'][0]['name'] == 'gitlabform_tests_group_with_user4'
+
+        gf = GitLabForm(config_string=config__approvers_single_user_and_single_group_change, project_or_group=GROUP_AND_PROJECT_NAME)
+        gf.main()
+
+        rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
+        assert len(rules) == 1
+        assert len(rules[0]['users']) == 1
+        assert rules[0]['users'][0]['username'] == 'merge_requests_user2'
+        assert len(rules[0]['groups']) == 1
+        assert rules[0]['groups'][0]['name'] == 'gitlabform_tests_group_with_user1_and_user2'
+
+    def test__if_fails_with_system_exit__more_than_one_user(self, gitlab):
+        gf = GitLabForm(config_string=config__approvers_more_than_one_user, project_or_group=GROUP_AND_PROJECT_NAME)
+        with pytest.raises(SystemExit):
+            gf.main()

--- a/gitlabform/gitlabform/test/test_merge_request_approvers.py
+++ b/gitlabform/gitlabform/test/test_merge_request_approvers.py
@@ -110,38 +110,50 @@ class TestMergeRequestApprovers:
         gf = GitLabForm(config_string=config__approvers_only_users, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
-        approvers = gitlab.get_approvals_settings(GROUP_AND_PROJECT_NAME)
-        assert len(approvers['approvers']) == 2
+        rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
+        assert len(rules) == 1
+        assert len(rules[0]['users']) == 2
+        assert len(rules[0]['groups']) == 0
 
     def test__if_change_works__only_users(self, gitlab):
         gf = GitLabForm(config_string=config__approvers_only_users, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
-        approvers = gitlab.get_approvals_settings(GROUP_AND_PROJECT_NAME)
-        assert len(approvers['approvers']) == 2
+        rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
+        assert len(rules) == 1
+        assert len(rules[0]['users']) == 2
+        assert len(rules[0]['groups']) == 0
 
         gf = GitLabForm(config_string=config__approvers_only_users_change, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
-        approvers = gitlab.get_approvals_settings(GROUP_AND_PROJECT_NAME)
-        assert len(approvers['approvers']) == 1
+        rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
+        assert len(rules) == 1
+        assert len(rules[0]['users']) == 1
+        assert len(rules[0]['groups']) == 0
 
     def test__if_it_works__only_groups(self, gitlab):
         gf = GitLabForm(config_string=config__approvers_only_groups, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
-        approvers = gitlab.get_approvals_settings(GROUP_AND_PROJECT_NAME)
-        assert len(approvers['approver_groups']) == 1
+        rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
+        assert len(rules) == 1
+        assert len(rules[0]['users']) == 0
+        assert len(rules[0]['groups']) == 1
 
     def test__if_change_works__only_groups(self, gitlab):
         gf = GitLabForm(config_string=config__approvers_only_groups, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
-        approvers = gitlab.get_approvals_settings(GROUP_AND_PROJECT_NAME)
-        assert len(approvers['approver_groups']) == 1
+        rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
+        assert len(rules) == 1
+        assert len(rules[0]['users']) == 0
+        assert len(rules[0]['groups']) == 1
 
         gf = GitLabForm(config_string=config__approvers_only_groups_change, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
-        approvers = gitlab.get_approvals_settings(GROUP_AND_PROJECT_NAME)
-        assert len(approvers['approver_groups']) == 2
+        rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
+        assert len(rules) == 1
+        assert len(rules[0]['users']) == 0
+        assert len(rules[0]['groups']) == 2

--- a/gitlabform/gitlabform/test/test_merge_request_approvers.py
+++ b/gitlabform/gitlabform/test/test_merge_request_approvers.py
@@ -110,38 +110,38 @@ class TestMergeRequestApprovers:
         gf = GitLabForm(config_string=config__approvers_only_users, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
-        approvers = gitlab.get_approvers(GROUP_AND_PROJECT_NAME)
+        approvers = gitlab.get_approvals_settings(GROUP_AND_PROJECT_NAME)
         assert len(approvers['approvers']) == 2
 
     def test__if_change_works__only_users(self, gitlab):
         gf = GitLabForm(config_string=config__approvers_only_users, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
-        approvers = gitlab.get_approvers(GROUP_AND_PROJECT_NAME)
+        approvers = gitlab.get_approvals_settings(GROUP_AND_PROJECT_NAME)
         assert len(approvers['approvers']) == 2
 
         gf = GitLabForm(config_string=config__approvers_only_users_change, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
-        approvers = gitlab.get_approvers(GROUP_AND_PROJECT_NAME)
+        approvers = gitlab.get_approvals_settings(GROUP_AND_PROJECT_NAME)
         assert len(approvers['approvers']) == 1
 
     def test__if_it_works__only_groups(self, gitlab):
         gf = GitLabForm(config_string=config__approvers_only_groups, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
-        approvers = gitlab.get_approvers(GROUP_AND_PROJECT_NAME)
+        approvers = gitlab.get_approvals_settings(GROUP_AND_PROJECT_NAME)
         assert len(approvers['approver_groups']) == 1
 
     def test__if_change_works__only_groups(self, gitlab):
         gf = GitLabForm(config_string=config__approvers_only_groups, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
-        approvers = gitlab.get_approvers(GROUP_AND_PROJECT_NAME)
+        approvers = gitlab.get_approvals_settings(GROUP_AND_PROJECT_NAME)
         assert len(approvers['approver_groups']) == 1
 
         gf = GitLabForm(config_string=config__approvers_only_groups_change, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
-        approvers = gitlab.get_approvers(GROUP_AND_PROJECT_NAME)
+        approvers = gitlab.get_approvals_settings(GROUP_AND_PROJECT_NAME)
         assert len(approvers['approver_groups']) == 2

--- a/gitlabform/gitlabform/test/test_merge_request_approvers.py
+++ b/gitlabform/gitlabform/test/test_merge_request_approvers.py
@@ -11,6 +11,8 @@ USER_BASE_NAME = 'merge_requests_user'  # user1, user2, ...
 
 GROUP_WITH_USER1_AND_USER2 = 'gitlabform_tests_group_with_user1_and_user2'
 
+GROUP_WITH_USER3 = 'gitlabform_tests_group_with_user3'
+
 GROUP_WITH_USER4 = 'gitlabform_tests_group_with_user4'
 
 DEVELOPER_ACCESS = 30
@@ -26,6 +28,9 @@ def gitlab(request):
 
     create_group(GROUP_WITH_USER1_AND_USER2)
     add_users_to_group(GROUP_WITH_USER1_AND_USER2, ['merge_requests_user1', 'merge_requests_user2'])
+
+    create_group(GROUP_WITH_USER3)
+    add_users_to_group(GROUP_WITH_USER3, ['merge_requests_user3'])
 
     create_group(GROUP_WITH_USER4)
     add_users_to_group(GROUP_WITH_USER4, ['merge_requests_user4'])
@@ -47,6 +52,8 @@ gitlab:
 
 project_settings:
   gitlabform_tests_group/merge_requests_project:
+    project_settings:
+      merge_requests_access_level: "enabled"
     merge_requests:
       approvals:
         approvals_before_merge: 1
@@ -63,6 +70,8 @@ gitlab:
 
 project_settings:
   gitlabform_tests_group/merge_requests_project:
+    project_settings:
+      merge_requests_access_level: "enabled"
     merge_requests:
       approvals:
         approvals_before_merge: 1
@@ -78,6 +87,8 @@ gitlab:
 
 project_settings:
   gitlabform_tests_group/merge_requests_project:
+    project_settings:
+      merge_requests_access_level: "enabled"
     merge_requests:
       approvals:
         approvals_before_merge: 1
@@ -85,6 +96,7 @@ project_settings:
         disable_overriding_approvers_per_merge_request: true
       approver_groups:
         - gitlabform_tests_group_with_user1_and_user2
+        - gitlabform_tests_group_with_user3
 """
 
 config__approvers_only_groups_change = """
@@ -93,13 +105,14 @@ gitlab:
 
 project_settings:
   gitlabform_tests_group/merge_requests_project:
+    project_settings:
+      merge_requests_access_level: "enabled"
     merge_requests:
       approvals:
         approvals_before_merge: 1
         reset_approvals_on_push: true
         disable_overriding_approvers_per_merge_request: true
       approver_groups:
-        - gitlabform_tests_group_with_user1_and_user2
         - gitlabform_tests_group_with_user4
 """
 
@@ -138,8 +151,8 @@ class TestMergeRequestApprovers:
 
         rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
         assert len(rules) == 1
+        assert len(rules[0]['groups']) == 2
         assert len(rules[0]['users']) == 0
-        assert len(rules[0]['groups']) == 1
 
     def test__if_change_works__only_groups(self, gitlab):
         gf = GitLabForm(config_string=config__approvers_only_groups, project_or_group=GROUP_AND_PROJECT_NAME)
@@ -147,13 +160,13 @@ class TestMergeRequestApprovers:
 
         rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
         assert len(rules) == 1
+        assert len(rules[0]['groups']) == 2
         assert len(rules[0]['users']) == 0
-        assert len(rules[0]['groups']) == 1
 
         gf = GitLabForm(config_string=config__approvers_only_groups_change, project_or_group=GROUP_AND_PROJECT_NAME)
         gf.main()
 
         rules = gitlab.get_approvals_rules(GROUP_AND_PROJECT_NAME)
         assert len(rules) == 1
+        assert len(rules[0]['groups']) == 1
         assert len(rules[0]['users']) == 0
-        assert len(rules[0]['groups']) == 2

--- a/run_gitlab_in_docker.sh
+++ b/run_gitlab_in_docker.sh
@@ -7,6 +7,9 @@ echo "Starting GitLab..."
 docker pull gitlab/gitlab-ee:latest
 
 mkdir -p config
+if [[ -f Gitlab.gitlab-license ]] ; then
+  cp Gitlab.gitlab-license config/
+fi
 mkdir -p logs
 mkdir -p data
 


### PR DESCRIPTION
Partial fix for #68. This will be improved when https://gitlab.com/gitlab-org/gitlab/issues/198770 will be fixed.