### PR TITLE
Adds `default_branch` example to `project_config`

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -96,6 +96,7 @@ group_settings:
 
     # keys and values here are as described at https://docs.gitlab.com/ce/api/projects.html#edit-project
     project_settings:
+      default_branch: main
       jobs_enabled: true
       public_jobs: false # "Public pipelines" checkbox in GitLab web UI
       visibility: internal


### PR DESCRIPTION
The example config makes extensive use of "main" as the default project branch, but the setting isn't present in the example config.
It falls under the umbrella `project_config` (with a full list of settings available via GitLab documentation), but given that it's relevant to other options in the config file, I've added it here as well.

(This solves issue #182 that I opened in ignorance.)