### PR TITLE
Disallow almost duplicate group and project names in the config

### DIFF
--- a/gitlabform/configuration/core.py
+++ b/gitlabform/configuration/core.py
@@ -56,6 +56,8 @@ class ConfigurationCore:
                     )
                     sys.exit(1)
 
+            self.find_almost_duplicates()
+
         except (FileNotFoundError, IOError):
             raise ConfigFileNotFoundException(config_path)
 
@@ -96,6 +98,67 @@ class ConfigurationCore:
                 raise KeyNotFoundException
 
         return current
+
+    def find_almost_duplicates(self):
+
+        # in GitLab groups and projects names are de facto case insensitive:
+        # you can change the case of both name and path BUT you cannot create
+        # 2 groups which names differ only with case and the same thing for
+        # projects. therefore we cannot allow such entries in the config,
+        # as they would be ambiguous.
+
+        for path in [
+            "group_settings",
+            "project_settings",
+            "skip_groups",
+            "skip_projects",
+        ]:
+            if self.get(path, 0):
+                almost_duplicates = self._find_almost_duplicates(path)
+                if almost_duplicates:
+                    logging.fatal(
+                        f"There are almost duplicates in the keys of {path} - they differ only in case.\n"
+                        f"They are: {', '.join(almost_duplicates)}"
+                        f"This is not allowed as we ignore the case for group and project names."
+                    )
+                    sys.exit(1)
+
+    def _find_almost_duplicates(self, configuration_path):
+        """
+        Checks given configuration key and reads its keys - if it is a dict - or elements - if it is a list.
+        Looks for items that are almost the same - they differ only in the case.
+        :param configuration_path: configuration path, f.e. "group_settings"
+        :return: list of items that have almost duplicates,
+                 or an empty list if none are found
+        """
+
+        dict_or_list = self.get(configuration_path)
+        if isinstance(dict_or_list, dict):
+            items = dict_or_list.keys()
+        else:
+            items = dict_or_list
+
+        items_with_lowercase_names = [x.lower() for x in items]
+
+        # casting these to sets will deduplicate the one with lowercase names
+        # lowering its cardinality if there were elements in it
+        # that before lowering differed only in case
+        if len(set(items)) != len(set(items_with_lowercase_names)):
+
+            # we have some almost duplicates, let's find them
+            almost_duplicates = []
+            for first_item in items:
+                occurrences = 0
+                for second_item in items_with_lowercase_names:
+                    if first_item.lower() == second_item.lower():
+                        occurrences += 1
+                        if occurrences == 2:
+                            almost_duplicates.append(first_item)
+                            break
+            return almost_duplicates
+
+        else:
+            return []
 
 
 class ConfigFileNotFoundException(Exception):

--- a/gitlabform/gitlab/groups.py
+++ b/gitlabform/gitlab/groups.py
@@ -2,10 +2,11 @@ from gitlabform.gitlab.core import GitLabCore, NotFoundException
 
 
 class GitLabGroups(GitLabCore):
-    def create_group(self, name, path):
+    def create_group(self, name, path, visibility="private"):
         data = {
             "name": name,
             "path": path,
+            "visibility": visibility,
         }
         return self._make_requests_to_api(
             "groups", data=data, method="POST", expected_codes=201

--- a/gitlabform/gitlabform/test/__init__.py
+++ b/gitlabform/gitlabform/test/__init__.py
@@ -42,11 +42,11 @@ def get_gitlab():
     return gl
 
 
-def create_group(group_name):
+def create_group(group_name, visibility="private"):
     try:
         gl.get_group(group_name)
     except NotFoundException:
-        gl.create_group(group_name, group_name)
+        gl.create_group(group_name, group_name, visibility)
 
 
 def create_project_in_group(group_name, project_name):

--- a/gitlabform/gitlabform/test/test_case_sensitivity.py
+++ b/gitlabform/gitlabform/test/test_case_sensitivity.py
@@ -1,0 +1,150 @@
+import pytest
+
+from gitlabform.gitlabform import GitLabForm
+from gitlabform.gitlabform.test import (
+    create_group,
+    create_project_in_group,
+    get_gitlab,
+)
+
+GROUP_NAME = "GroupNameWithVaryingCase"
+PROJECT_NAME = "ProjectWithVaryingCase"
+GROUP_AND_PROJECT_NAME = GROUP_NAME + "/" + PROJECT_NAME
+
+
+@pytest.fixture(scope="module")
+def gitlab(request):
+    gl = get_gitlab()
+
+    gl.delete_group(GROUP_NAME)
+    create_group(GROUP_NAME, "internal")
+    create_project_in_group(GROUP_NAME, PROJECT_NAME)
+
+    def fin():
+        pass
+        gl.delete_project(GROUP_AND_PROJECT_NAME)
+        gl.delete_group(GROUP_NAME)
+
+    request.addfinalizer(fin)
+    return gl  # provide fixture value
+
+
+config_with_different_case_group = """
+    gitlab:
+      api_version: 4
+    
+    group_settings:
+      GROUPnameWITHvaryingCASE: # different case than defined above 
+        project_settings:
+          visibility: internal
+"""
+
+config_with_different_case_project = """
+    gitlab:
+      api_version: 4
+    
+    project_settings:
+      GroupNameWithVaryingCase/projectwithvaryingcase: # different case than defined above 
+        project_settings:
+          visibility: internal
+"""
+
+config_with_different_case_duplicate_groups = """
+    gitlab:
+      api_version: 4
+    
+    group_settings:
+      groupnamewithvaryingcase:
+        project_settings:
+          visibility: internal
+      GROUPnameWITHvaryingCASE: # different case than defined above 
+        project_settings:
+          visibility: internal
+"""
+
+config_with_different_case_duplicate_projects = """
+    gitlab:
+      api_version: 4
+    
+    project_settings:
+      GroupNameWithVaryingCase/projectwithvaryingcase:
+        project_settings:
+          visibility: internal
+      GroupNameWithVaryingCase/ProjectWithVaryingCase:
+        project_settings:
+          visibility: internal
+"""
+
+config_with_different_case_duplicate_skip_groups = """
+    gitlab:
+      api_version: 4
+    
+    skip_groups:
+      - groupnamewithvaryingcase
+      - GROUPnameWITHvaryingCASE
+"""
+
+config_with_different_case_duplicate_skip_projects = """
+    gitlab:
+      api_version: 4
+    
+    skip_projects:
+      - GroupNameWithVaryingCase/projectwithvaryingcase
+      - GroupNameWithVaryingCase/ProjectWithVaryingCase
+"""
+
+
+class TestCaseSensitivitySettings:
+    def test__config_with_different_case_group(self, gitlab):
+        settings = gitlab.get_project_settings(GROUP_AND_PROJECT_NAME)
+        assert settings["visibility"] == "private"
+
+        gf = GitLabForm(
+            config_string=config_with_different_case_group,
+            project_or_group=GROUP_AND_PROJECT_NAME,
+        )
+        gf.main()
+
+        settings = gitlab.get_project_settings(GROUP_AND_PROJECT_NAME)
+        assert settings["visibility"] == "internal"
+
+    def test__config_with_different_case_project(self, gitlab):
+        settings = gitlab.get_project_settings(GROUP_AND_PROJECT_NAME)
+        assert settings["visibility"] == "private"
+
+        gf = GitLabForm(
+            config_string=config_with_different_case_project,
+            project_or_group=GROUP_AND_PROJECT_NAME,
+        )
+        gf.main()
+
+        settings = gitlab.get_project_settings(GROUP_AND_PROJECT_NAME)
+        assert settings["visibility"] == "internal"
+
+    def test__config_with_different_case_duplicate_projects(self, gitlab):
+        with pytest.raises(SystemExit):
+            GitLabForm(
+                config_string=config_with_different_case_duplicate_projects,
+                project_or_group=GROUP_AND_PROJECT_NAME,
+            )
+
+    def test__config_with_different_case_duplicate_groups(self, gitlab):
+        with pytest.raises(SystemExit):
+            GitLabForm(
+                config_string=config_with_different_case_duplicate_groups,
+                project_or_group=GROUP_AND_PROJECT_NAME,
+            )
+
+    def test__config_with_different_case_duplicate_skip_groups(self, gitlab):
+        with pytest.raises(SystemExit):
+            GitLabForm(
+                config_string=config_with_different_case_duplicate_skip_groups,
+                project_or_group=GROUP_AND_PROJECT_NAME,
+            )
+
+    def test__config_with_different_case_duplicate_skip_projects(self, gitlab):
+        with pytest.raises(SystemExit):
+            GitLabForm(
+                config_string=config_with_different_case_duplicate_skip_projects,
+                project_or_group=GROUP_AND_PROJECT_NAME,
+            )


### PR DESCRIPTION
* Disallow almost duplicate group and project names in the config
* Ignore project and group paths case when looking for their configs (TODO)

This will fix #160
