### PR TITLE
Add sample config for CI CD variables scoped to environment

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -329,6 +329,28 @@ project_settings:
         title: ssh_key_name_that_is_shown_in_gitlab_3
         can_push: false
 
+    secret_variables:
+      # CI CD variable for this project. Variables can be scoped to an "environment".
+      # Scoping to environment also allows using the same "key" name for multiple variables.
+      # This can simplify CI Config file because the appropriate variable will be exposed
+      # by GitLab to the job that is targetting a given environment. If the same "key" name
+      # is used for different environments, you'll need to add filter[environment_scope] to
+      # configuration as shown below.
+      aws_access_key_id_for_deploying_in_production:
+        key: APP_HOST_AWS_ACCESS_KEY_ID
+        value: "prod-value-1234"
+        protected: true
+        masked: true
+        environment_scope: production
+        filter[environment_scope]: production
+      aws_access_key_id_for_deploying_in_staging:
+        key: APP_HOST_AWS_ACCESS_KEY_ID
+        value: "staging-value-1234"
+        protected: true
+        masked: true
+        environment_scope: staging
+        filter[environment_scope]: staging
+
     branches:
       # see comment above - this branch config will be ADDED to the branches configured on a group level
       special_branch:


### PR DESCRIPTION
This change adds a sample configuration that shows how to add
multiple CI CD variables with the same name but scoped to different
deployment environments.

closes #186 
