### PR TITLE
Update to allow a '0' access for Protected tags - issue #172

### DIFF
--- a/gitlabform/gitlab/tags.py
+++ b/gitlabform/gitlab/tags.py
@@ -23,7 +23,7 @@ class GitLabTags(GitLabCore):
 
     def protect_tag(self, project_and_group_name, tag_name, create_access_level):
         data = {"name": tag_name}
-        if create_access_level:
+        if create_access_level != None:
             data["create_access_level"] = create_access_level
         return self._make_requests_to_api(
             "projects/%s/protected_tags",

--- a/gitlabform/gitlab/test/__init__.py
+++ b/gitlabform/gitlab/test/__init__.py
@@ -1,0 +1,42 @@
+import os
+
+from gitlabform.gitlab import GitLab
+from gitlabform.gitlab.core import NotFoundException, UnexpectedResponseException
+
+CONFIG = """
+gitlab:
+  # GITLAB_URL and GITLAB_TOKEN should be in the env variables
+  api_version: 4
+    """
+
+# automate reading files created by run_gitlab_in_docker.sh to run tests in PyCharm / IntelliJ
+# (workaround for lack of this feature: https://youtrack.jetbrains.com/issue/PY-5543 )
+
+env_vars_and_file_paths = {
+    "GITLAB_URL": "gitlab_url.txt",
+    "GITLAB_TOKEN": "gitlab_token.txt",
+}
+
+for env_var, file_path in env_vars_and_file_paths.items():
+    if env_var not in os.environ:
+        print(f"{env_var} not set - trying to read it from {file_path} ...")
+        if os.path.isfile(file_path):
+            try:
+                with open(file_path, "r") as file:
+                    os.environ[env_var] = file.read().replace("\n", "")
+                    print(f"{env_var} set!")
+            except Exception as e:
+                print(f"Failed to read {file_path}: {e}")
+        else:
+            print(f"{file_path} doesn't exist.")
+
+GROUP_NAME = "gitlabform_tests_group"
+
+DEVELOPER_ACCESS = 30
+OWNER_ACCESS = 50
+
+gl = GitLab(config_string=CONFIG)
+
+
+def get_gitlab():
+    return gl

--- a/gitlabform/gitlab/test/test_tags.py
+++ b/gitlabform/gitlab/test/test_tags.py
@@ -1,19 +1,19 @@
-import pytest
-
-import pdb 
-import logging
-
-import json
-
-logger = logging.getLogger(__name__)
-
-from gitlabform.gitlabform import GitLabForm
 from gitlabform.gitlabform.test import (
     create_group,
     create_project_in_group,
     get_gitlab,
     GROUP_NAME,
 )
+from gitlabform.gitlabform import GitLabForm
+import pytest
+
+import pdb
+import logging
+
+import json
+
+logger = logging.getLogger(__name__)
+
 
 PROJECT_NAME = "project_settings_project"
 GROUP_AND_PROJECT_NAME = GROUP_NAME + "/" + PROJECT_NAME
@@ -67,4 +67,3 @@ class TestTagPermissionNoAccess:
         project = gitlab.get_project(GROUP_AND_PROJECT_NAME)
 
         assert project["archived"] is False
-

--- a/gitlabform/gitlab/test/test_tags.py
+++ b/gitlabform/gitlab/test/test_tags.py
@@ -1,0 +1,70 @@
+import pytest
+
+import pdb 
+import logging
+
+import json
+
+logger = logging.getLogger(__name__)
+
+from gitlabform.gitlabform import GitLabForm
+from gitlabform.gitlabform.test import (
+    create_group,
+    create_project_in_group,
+    get_gitlab,
+    GROUP_NAME,
+)
+
+PROJECT_NAME = "project_settings_project"
+GROUP_AND_PROJECT_NAME = GROUP_NAME + "/" + PROJECT_NAME
+
+
+@pytest.fixture(scope="module")
+def gitlab(request):
+    create_group(GROUP_NAME)
+    create_project_in_group(GROUP_NAME, PROJECT_NAME)
+
+    gl = get_gitlab()
+
+    def fin():
+        gl.delete_project(GROUP_AND_PROJECT_NAME)
+
+    request.addfinalizer(fin)
+    return gl  # provide fixture value
+
+
+config_tag_permission_no_access = (
+    """
+gitlab:
+  api_version: 4
+
+project_settings:
+  """
+    + GROUP_AND_PROJECT_NAME
+    + """:
+    project_settings:
+        default_branch: main
+        tags:
+            "*":
+                protected: true
+                create_access_level: 0 
+            "v*":
+                protected: true
+                create_access_level: 40
+
+"""
+)
+
+
+class TestTagPermissionNoAccess:
+    def test__tag_permission_no_access(self, gitlab):
+        gf = GitLabForm(
+            config_string=config_tag_permission_no_access,
+            project_or_group=GROUP_AND_PROJECT_NAME,
+        )
+        gf.main()
+
+        project = gitlab.get_project(GROUP_AND_PROJECT_NAME)
+
+        assert project["archived"] is False
+


### PR DESCRIPTION
quick change, tested locally, now getting

{"create_access_level": 0, "name": "*"}