### PR TITLE
Add only users to project if they are not properly set

### DIFF
--- a/gitlabform/gitlab/members.py
+++ b/gitlabform/gitlab/members.py
@@ -48,6 +48,19 @@ class GitLabMembers(GitLabCore):
 
         return self._make_requests_to_api(url_template, group_name, paginated=True)
 
+    def get_members_from_project(self, project_and_group_name):
+        members = self._make_requests_to_api(
+            "projects/%s/members", project_and_group_name
+        )
+        # it will return {username1: {...api info about username1...}, username2: {...}}
+        # otherwise it can get very long to iterate when checking if a user
+        # is already in the project if there are a lot of users to check
+        final_members = {}
+        for member in members:
+            final_members[member["username"]] = member
+
+        return final_members
+
     def add_member_to_group(self, group_name, username, access_level, expires_at=None):
         data = {"user_id": self._get_user_id(username), "expires_at": expires_at}
         if access_level is not None:

--- a/gitlabform/gitlab/projects.py
+++ b/gitlabform/gitlab/projects.py
@@ -422,6 +422,18 @@ class GitLabProjects(GitLabCore):
 
         return data
 
+    def get_groups_from_project(self, project_and_group_name):
+        # couldn't find an API call that was giving me directly
+        # the shared groups, so I'm using directly the GET /projects/:id call
+        project_info = self._make_requests_to_api("projects/%s", project_and_group_name)
+
+        # it will return {group_name: {...api info about group_name...}, ...}
+        groups = {}
+        for group in project_info["shared_with_groups"]:
+            groups[group["group_name"]] = group
+
+        return groups
+
     def share_with_group(
         self, project_and_group_name, group_name, group_access, expires_at
     ):

--- a/gitlabform/gitlabform/processors/project/members_processor.py
+++ b/gitlabform/gitlabform/processors/project/members_processor.py
@@ -16,39 +16,75 @@ class MembersProcessor(AbstractProcessor):
     def _process_configuration(self, project_and_group: str, configuration: dict):
         groups = configuration.get("members|groups")
         if groups:
+            current_groups = self.gitlab.get_groups_from_project(project_and_group)
             for group in groups:
-                logging.debug("Setting group '%s' as a member", group)
-                access = (
+                expires_at = (
+                    groups[group]["expires_at"].strftime("%Y-%m-%d")
+                    if "expires_at" in groups[group]
+                    else None
+                )
+                access_level = (
                     groups[group]["group_access"]
                     if "group_access" in groups[group]
                     else None
                 )
-                expiry = (
-                    groups[group]["expires_at"] if "expires_at" in groups[group] else ""
-                )
 
-                # we will remove group access first and then re-add them,
-                # to ensure that the groups have the expected access level
-                self.gitlab.unshare_with_group(project_and_group, group)
-                self.gitlab.share_with_group(project_and_group, group, access, expiry)
+                # we only add the group if it doesn't have the correct settings
+                if (
+                    group in current_groups
+                    and expires_at == current_groups[group]["expires_at"]
+                    and access_level == current_groups[group]["group_access_level"]
+                ):
+                    logging.info("Ignoring group '%s' as it is already a member", group)
+                    logging.info(
+                        "Current settings for '%s' are: %s"
+                        % (group, current_groups[group])
+                    )
+                else:
+                    logging.debug("Setting group '%s' as a member", group)
+                    access = access_level
+                    expiry = expires_at
+
+                    # we will remove group access first and then re-add them,
+                    # to ensure that the groups have the expected access level
+                    self.gitlab.unshare_with_group(project_and_group, group)
+                    self.gitlab.share_with_group(
+                        project_and_group, group, access, expiry
+                    )
 
         users = configuration.get("members|users")
         if users:
+            current_members = self.gitlab.get_members_from_project(project_and_group)
             for user in users:
-                logging.debug("Setting user '%s' as a member", user)
-                access = (
+                expires_at = (
+                    users[user]["expires_at"].strftime("%Y-%m-%d")
+                    if "expires_at" in users[user]
+                    else None
+                )
+                access_level = (
                     users[user]["access_level"]
                     if "access_level" in users[user]
                     else None
                 )
-                expiry = (
-                    users[user]["expires_at"] if "expires_at" in users[user] else ""
-                )
-                self.gitlab.remove_member_from_project(project_and_group, user)
-                self.gitlab.add_member_to_project(
-                    project_and_group, user, access, expiry
-                )
-
+                # we only add the user if it doesn't have the correct settings
+                if (
+                    user in current_members
+                    and expires_at == current_members[user]["expires_at"]
+                    and access_level == current_members[user]["access_level"]
+                ):
+                    logging.info("Ignoring user '%s' as it is already a member", user)
+                    logging.info(
+                        "Current settings for '%s' are: %s"
+                        % (user, current_members[user])
+                    )
+                else:
+                    logging.info("Setting user '%s' as a member", user)
+                    access = access_level
+                    expiry = expires_at
+                    self.gitlab.remove_member_from_project(project_and_group, user)
+                    self.gitlab.add_member_to_project(
+                        project_and_group, user, access, expiry
+                    )
         if not groups and not users:
             cli_ui.error(
                 "Project members configuration section has to contain"


### PR DESCRIPTION
Fixes #101. Checks if the user is added with the correct access level and
expire date. If those values are not the ones defined by gitlabform
the user gets deleted if it's present and added again.

This commit also fixes #207, trying to use "expires_at" when setting
a user was making gitlabform to fail.