### PR TITLE
Add support for maintaining groups that are shared with other groups

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -190,7 +190,11 @@ projects_and_groups:
       my-user:
         access_level: 50 # = Owner, see "valid access levels" at https://docs.gitlab.com/ee/api/members.html
 
-    # if this flag is set to 'true', then removing a user the above config will remove the user from the group
+    group_shared_with:
+      another-group:
+        group_access_level: 10
+
+    # if this flag is set to 'true', then removing a user or group from the above config will remove the user from the group
     # note: you have to keep at least 1 user with Owner level (50) - it's required by GitLab
     enforce_group_members: true  # default: false
 
@@ -399,7 +403,7 @@ projects_and_groups:
             variable_type: file # optional parameter, defaults to 'env_var'
           other_variable:
             value: another_value
-      # this one will be deleted if exists 
+      # this one will be deleted if exists
       "Obsolete schedule":
         delete: true
 

--- a/gitlabform/gitlab/groups.py
+++ b/gitlabform/gitlab/groups.py
@@ -149,3 +149,31 @@ class GitLabGroups(GitLabCore):
             "DELETE",
             expected_codes=[200, 202, 204, 404],
         )
+
+    def get_group_shared_with(self, group):
+        group = self.get_group_case_insensitive(group)
+
+        return group["shared_with_groups"]
+
+    def add_share_to_group(
+        self, group, share_with_group_id, group_access, expires_at=None
+    ):
+        data = {"group_id": share_with_group_id, "expires_at": expires_at}
+        if group_access is not None:
+            data["group_access"] = group_access
+
+        return self._make_requests_to_api(
+            "groups/%s/share",
+            group,
+            method="POST",
+            data=data,
+            expected_codes=[200, 201],
+        )
+
+    def remove_share_from_group(self, group, share_with_group_id):
+        return self._make_requests_to_api(
+            "groups/%s/share/%s",
+            (group, share_with_group_id),
+            method="DELETE",
+            expected_codes=204,
+        )

--- a/gitlabform/gitlab/groups.py
+++ b/gitlabform/gitlab/groups.py
@@ -8,7 +8,7 @@ from gitlabform.gitlab.core import GitLabCore, NotFoundException
 
 
 class GitLabGroups(GitLabCore):
-    @functools.lru_cache
+    @functools.lru_cache()
     def get_group_id_case_insensitive(self, some_string):
         # Cache the mapping from some_string -> id, as that won't change during our run.
         return self.get_group_case_insensitive(some_string)["id"]

--- a/gitlabform/gitlab/groups.py
+++ b/gitlabform/gitlab/groups.py
@@ -6,6 +6,7 @@ import cli_ui
 from gitlabform import EXIT_INVALID_INPUT
 from gitlabform.gitlab.core import GitLabCore, NotFoundException
 
+
 class GitLabGroups(GitLabCore):
     @functools.lru_cache
     def get_group_id_case_insensitive(self, some_string):
@@ -169,7 +170,9 @@ class GitLabGroups(GitLabCore):
         self, group, share_with_group_name, group_access, expires_at=None
     ):
         try:
-            share_with_group_id = self.get_group_id_case_insensitive(share_with_group_name)
+            share_with_group_id = self.get_group_id_case_insensitive(
+                share_with_group_name
+            )
         except NotFoundException:
             cli_ui.error(f"Group {share_with_group_name} not found.")
             sys.exit(EXIT_INVALID_INPUT)
@@ -188,7 +191,9 @@ class GitLabGroups(GitLabCore):
 
     def remove_share_from_group(self, group, share_with_group_name):
         try:
-            share_with_group_id = self.get_group_id_case_insensitive(share_with_group_name)
+            share_with_group_id = self.get_group_id_case_insensitive(
+                share_with_group_name
+            )
         except NotFoundException:
             cli_ui.error(f"Group {share_with_group_name} not found.")
             sys.exit(EXIT_INVALID_INPUT)

--- a/gitlabform/gitlabform/processors/group/__init__.py
+++ b/gitlabform/gitlabform/processors/group/__init__.py
@@ -8,6 +8,9 @@ from gitlabform.gitlabform.processors.group.group_members_processor import (
 from gitlabform.gitlabform.processors.group.group_secret_variables_processor import (
     GroupSecretVariablesProcessor,
 )
+from gitlabform.gitlabform.processors.group.group_shared_with_processor import (
+    GroupSharedWithProcessor,
+)
 from gitlabform.gitlabform.processors.group.group_settings_processor import (
     GroupSettingsProcessor,
 )
@@ -19,6 +22,7 @@ class GroupProcessors(object):
             GroupSecretVariablesProcessor(gitlab),
             GroupSettingsProcessor(gitlab),
             GroupMembersProcessor(gitlab),
+            GroupSharedWithProcessor(gitlab),
         ]
 
     def process_group(

--- a/gitlabform/gitlabform/processors/group/group_shared_with_processor.py
+++ b/gitlabform/gitlabform/processors/group/group_shared_with_processor.py
@@ -16,7 +16,6 @@ class GroupSharedWithProcessor(AbstractProcessor):
 
     def _process_configuration(self, group: str, configuration: dict):
         groups_to_set_by_group_name = configuration.get("group_shared_with")
-
         if groups_to_set_by_group_name is None:
             groups_to_set_by_group_name = {}
 
@@ -44,12 +43,10 @@ class GroupSharedWithProcessor(AbstractProcessor):
 
             if share_with_group_name in groups_before_by_group_name:
 
-                group_access_before = groups_before_by_group_name[
-                    share_with_group_name
-                ]["group_access_level"]
-                expires_at_before = groups_before_by_group_name[share_with_group_name][
-                    "expires_at"
+                group_access_before = groups_before_by_group_name[share_with_group_name][
+                    "group_access_level"
                 ]
+                expires_at_before = groups_before_by_group_name[share_with_group_name]["expires_at"]
 
                 if (
                     group_access_before == group_access_to_set
@@ -68,16 +65,12 @@ class GroupSharedWithProcessor(AbstractProcessor):
                     # to ensure that the group has the expected access level
                     self.gitlab.remove_share_from_group(group, share_with_group_name)
                     self.gitlab.add_share_to_group(
-                        group,
-                        share_with_group_name,
-                        group_access_to_set,
-                        expires_at_to_set,
+                        group, share_with_group_name, group_access_to_set, expires_at_to_set
                     )
 
             else:
                 logging.debug(
-                    "Adding group '%s' who previously was not a member.",
-                    share_with_group_name,
+                    "Adding group '%s' who previously was not a member.", share_with_group_name
                 )
                 self.gitlab.add_share_to_group(
                     group, share_with_group_name, group_access_to_set, expires_at_to_set
@@ -85,8 +78,8 @@ class GroupSharedWithProcessor(AbstractProcessor):
 
         if configuration.get("enforce_group_members"):
             # remove groups not configured explicitly
-            groups_not_configured = set(groups_before_by_group_name) - set(
-                groups_to_set_by_group_name
+            groups_not_configured = (
+                set(groups_before_by_group_name) - set(groups_to_set_by_group_name)
             )
             for group_name in groups_not_configured:
                 logging.debug(

--- a/gitlabform/gitlabform/processors/group/group_shared_with_processor.py
+++ b/gitlabform/gitlabform/processors/group/group_shared_with_processor.py
@@ -43,10 +43,12 @@ class GroupSharedWithProcessor(AbstractProcessor):
 
             if share_with_group_name in groups_before_by_group_name:
 
-                group_access_before = groups_before_by_group_name[share_with_group_name][
-                    "group_access_level"
+                group_access_before = groups_before_by_group_name[
+                    share_with_group_name
+                ]["group_access_level"]
+                expires_at_before = groups_before_by_group_name[share_with_group_name][
+                    "expires_at"
                 ]
-                expires_at_before = groups_before_by_group_name[share_with_group_name]["expires_at"]
 
                 if (
                     group_access_before == group_access_to_set
@@ -65,12 +67,16 @@ class GroupSharedWithProcessor(AbstractProcessor):
                     # to ensure that the group has the expected access level
                     self.gitlab.remove_share_from_group(group, share_with_group_name)
                     self.gitlab.add_share_to_group(
-                        group, share_with_group_name, group_access_to_set, expires_at_to_set
+                        group,
+                        share_with_group_name,
+                        group_access_to_set,
+                        expires_at_to_set,
                     )
 
             else:
                 logging.debug(
-                    "Adding group '%s' who previously was not a member.", share_with_group_name
+                    "Adding group '%s' who previously was not a member.",
+                    share_with_group_name,
                 )
                 self.gitlab.add_share_to_group(
                     group, share_with_group_name, group_access_to_set, expires_at_to_set
@@ -78,8 +84,8 @@ class GroupSharedWithProcessor(AbstractProcessor):
 
         if configuration.get("enforce_group_members"):
             # remove groups not configured explicitly
-            groups_not_configured = (
-                set(groups_before_by_group_name) - set(groups_to_set_by_group_name)
+            groups_not_configured = set(groups_before_by_group_name) - set(
+                groups_to_set_by_group_name
             )
             for group_name in groups_not_configured:
                 logging.debug(

--- a/gitlabform/gitlabform/processors/group/group_shared_with_processor.py
+++ b/gitlabform/gitlabform/processors/group/group_shared_with_processor.py
@@ -44,10 +44,12 @@ class GroupSharedWithProcessor(AbstractProcessor):
 
             if share_with_group_name in groups_before_by_group_name:
 
-                group_access_before = groups_before_by_group_name[share_with_group_name][
-                    "group_access_level"
+                group_access_before = groups_before_by_group_name[
+                    share_with_group_name
+                ]["group_access_level"]
+                expires_at_before = groups_before_by_group_name[share_with_group_name][
+                    "expires_at"
                 ]
-                expires_at_before = groups_before_by_group_name[share_with_group_name]["expires_at"]
 
                 if (
                     group_access_before == group_access_to_set
@@ -66,12 +68,16 @@ class GroupSharedWithProcessor(AbstractProcessor):
                     # to ensure that the group has the expected access level
                     self.gitlab.remove_share_from_group(group, share_with_group_name)
                     self.gitlab.add_share_to_group(
-                        group, share_with_group_name, group_access_to_set, expires_at_to_set
+                        group,
+                        share_with_group_name,
+                        group_access_to_set,
+                        expires_at_to_set,
                     )
 
             else:
                 logging.debug(
-                    "Adding group '%s' who previously was not a member.", share_with_group_name
+                    "Adding group '%s' who previously was not a member.",
+                    share_with_group_name,
                 )
                 self.gitlab.add_share_to_group(
                     group, share_with_group_name, group_access_to_set, expires_at_to_set
@@ -79,8 +85,8 @@ class GroupSharedWithProcessor(AbstractProcessor):
 
         if configuration.get("enforce_group_members"):
             # remove groups not configured explicitly
-            groups_not_configured = (
-                set(groups_before_by_group_name) - set(groups_to_set_by_group_name)
+            groups_not_configured = set(groups_before_by_group_name) - set(
+                groups_to_set_by_group_name
             )
             for group_name in groups_not_configured:
                 logging.debug(

--- a/gitlabform/gitlabform/processors/group/group_shared_with_processor.py
+++ b/gitlabform/gitlabform/processors/group/group_shared_with_processor.py
@@ -16,7 +16,6 @@ class GroupSharedWithProcessor(AbstractProcessor):
 
     def _process_configuration(self, group: str, configuration: dict):
         groups_to_set_by_groupname = configuration.get("group_shared_with")
-        print(groups_to_set_by_groupname)
         if groups_to_set_by_groupname is None:
             groups_to_set_by_groupname = {}
 
@@ -51,7 +50,6 @@ class GroupSharedWithProcessor(AbstractProcessor):
                 else None
             )
 
-            print(groups_before_by_group_id)
             if group_id in groups_before_by_group_id:
 
                 group_access_before = groups_before_by_group_id[group_id][
@@ -83,7 +81,6 @@ class GroupSharedWithProcessor(AbstractProcessor):
                 logging.debug(
                     "Adding group '%s' who previously was not a member.", groupname
                 )
-                print(f"Adding group '{groupname}' who previously was not a member.")
                 self.gitlab.add_share_to_group(
                     group, group_id, group_access_to_set, expires_at_to_set
                 )

--- a/gitlabform/gitlabform/processors/group/group_shared_with_processor.py
+++ b/gitlabform/gitlabform/processors/group/group_shared_with_processor.py
@@ -1,0 +1,107 @@
+import logging
+import sys
+
+import cli_ui
+
+from gitlabform.gitlab import GitLab
+from gitlabform.gitlab.core import NotFoundException
+from gitlabform import EXIT_INVALID_INPUT
+from gitlabform.gitlabform.processors.abstract_processor import AbstractProcessor
+
+
+class GroupSharedWithProcessor(AbstractProcessor):
+    def __init__(self, gitlab: GitLab):
+        super().__init__("group_shared_with")
+        self.gitlab = gitlab
+
+    def _process_configuration(self, group: str, configuration: dict):
+        groups_to_set_by_groupname = configuration.get("group_shared_with")
+        print(groups_to_set_by_groupname)
+        if groups_to_set_by_groupname is None:
+            groups_to_set_by_groupname = {}
+
+        # group users before by group name
+        groups_before = self.gitlab.get_group_case_insensitive(group)[
+            "shared_with_groups"
+        ]
+        logging.debug("Group shared with BEFORE: %s", groups_before)
+        groups_before_by_group_id = dict()
+        for share_details in groups_before:
+            groups_before_by_group_id[share_details["group_id"]] = share_details
+
+        groups_to_set_by_group_id = set()
+
+        for groupname in groups_to_set_by_groupname:
+
+            try:
+                group_id = self.gitlab.get_group_case_insensitive(groupname)["id"]
+            except NotFoundException:
+                cli_ui.error(f"Group {groupname} not found.")
+                sys.exit(EXIT_INVALID_INPUT)
+
+            groups_to_set_by_group_id.add(group_id)
+
+            group_access_to_set = groups_to_set_by_groupname[groupname][
+                "group_access_level"
+            ]
+
+            expires_at_to_set = (
+                groups_to_set_by_groupname[groupname]["expires_at"]
+                if "expires_at" in groups_to_set_by_groupname[groupname]
+                else None
+            )
+
+            print(groups_before_by_group_id)
+            if group_id in groups_before_by_group_id:
+
+                group_access_before = groups_before_by_group_id[group_id][
+                    "group_access_level"
+                ]
+                expires_at_before = groups_before_by_group_id[group_id]["expires_at"]
+
+                if (
+                    group_access_before == group_access_to_set
+                    and expires_at_before == expires_at_to_set
+                ):
+                    logging.debug(
+                        "Nothing to change for group '%s' - same config now as to set.",
+                        groupname,
+                    )
+                else:
+                    logging.debug(
+                        "Re-adding group '%s' to change their access level or expires at.",
+                        groupname,
+                    )
+                    # we will remove the group first and then re-add them,
+                    # to ensure that the group has the expected access level
+                    self.gitlab.remove_share_from_group(group, group_id)
+                    self.gitlab.add_share_to_group(
+                        group, group_id, group_access_to_set, expires_at_to_set
+                    )
+
+            else:
+                logging.debug(
+                    "Adding group '%s' who previously was not a member.", groupname
+                )
+                print(f"Adding group '{groupname}' who previously was not a member.")
+                self.gitlab.add_share_to_group(
+                    group, group_id, group_access_to_set, expires_at_to_set
+                )
+
+        if configuration.get("enforce_group_members"):
+            # remove groups not configured explicitly
+            groups_not_configured = (
+                set(groups_before_by_group_id) - groups_to_set_by_group_id
+            )
+            for group_id in groups_not_configured:
+                logging.debug(
+                    "Removing group '%s' who is not configured to be a member.",
+                    group_id,
+                )
+                self.gitlab.remove_share_from_group(group, group_id)
+        else:
+            logging.debug("Not enforcing group members.")
+
+        logging.debug(
+            "Group shared with AFTER: %s", self.gitlab.get_group_members(group)
+        )

--- a/gitlabform/gitlabform/test/__init__.py
+++ b/gitlabform/gitlabform/test/__init__.py
@@ -62,6 +62,24 @@ def create_group(group_name):
     gl.create_group(group_name, group_name)
 
 
+def create_groups(group_base_name, no_of_groups):
+    groups = []
+    for group_no in range(1, no_of_groups + 1):
+        group_name = group_base_name + str(group_no)
+        try:
+            gl.get_group_case_insensitive(group_name)
+        except NotFoundException:
+            gl.create_group(group_name, group_name)
+        groups.append(group_name)
+    return groups
+
+
+def delete_groups(group_base_name, no_of_groups):
+    for group_no in range(1, no_of_groups + 1):
+        group_name = group_base_name + str(group_no)
+        gl.delete_group(group_name)
+
+
 def create_project(group_name, project_name):
     group = gl.get_group(group_name)
     gl.create_project(

--- a/gitlabform/gitlabform/test/conftest.py
+++ b/gitlabform/gitlabform/test/conftest.py
@@ -3,6 +3,8 @@ import pytest
 from gitlabform.gitlabform.test import (
     get_gitlab,
     create_group,
+    create_groups,
+    delete_groups,
     create_project,
     get_random_name,
     create_users,
@@ -61,6 +63,19 @@ def other_project(group):
 
     gl = get_gitlab()
     gl.delete_project(f"{group}/{project_name}")
+
+
+@pytest.fixture(scope="class")
+def groups(users):
+    no_of_groups = 4
+
+    group_name_base = get_random_name()
+    print(f"groups {group_name_base} {no_of_groups}")
+    groups = create_groups(group_name_base, no_of_groups)
+
+    yield groups
+
+    delete_groups(group_name_base, no_of_groups)
 
 
 @pytest.fixture(scope="class")

--- a/gitlabform/gitlabform/test/conftest.py
+++ b/gitlabform/gitlabform/test/conftest.py
@@ -70,7 +70,6 @@ def groups(users):
     no_of_groups = 4
 
     group_name_base = get_random_name()
-    print(f"groups {group_name_base} {no_of_groups}")
     groups = create_groups(group_name_base, no_of_groups)
 
     yield groups

--- a/gitlabform/gitlabform/test/test_group_shared_with.py
+++ b/gitlabform/gitlabform/test/test_group_shared_with.py
@@ -1,0 +1,164 @@
+import pytest
+
+from gitlabform.gitlabform.test import (
+    run_gitlabform,
+)
+
+
+@pytest.fixture(scope="function")
+def one_owner(gitlab, group, users):
+
+    gitlab.add_member_to_group(group, users[0], 50)
+    gitlab.remove_member_from_group(group, "root")
+
+    yield group
+
+    # we are running tests with root's token, so every group is created
+    # with a single user - root as owner. we restore the group to
+    # this state here.
+
+    gitlab.add_member_to_group(group, "root", 50)
+
+    # we try to remove all users, not just those added above,
+    # on purpose, as more may have been added in the tests
+    for user in users:
+        gitlab.remove_member_from_group(group, user)
+
+
+class TestGroupSharedWith:
+    def test__add_group(self, gitlab, group, users, groups, one_owner):
+        no_of_members_before = len(gitlab.get_group_members(group))
+
+        add_shared_with = f"""
+        projects_and_groups:
+          {group}/*:
+            group_members:
+              {users[0]}:
+                access_level: 50
+            group_shared_with:
+              {groups[0]}:
+                group_access_level: 30
+              {groups[1]}:
+                group_access_level: 30
+        """
+
+        run_gitlabform(add_shared_with, group)
+
+        members = gitlab.get_group_members(group)
+        assert len(members) == no_of_members_before, members
+
+        shared_with = gitlab.get_group_shared_with(group)
+        assert len(shared_with) == 2
+
+    def test__remove_group(self, gitlab, group, users, groups, one_owner):
+
+        no_of_members_before = len(gitlab.get_group_members(group))
+        no_of_shared_with_before = len(gitlab.get_group_shared_with(group))
+
+        remove_users = f"""
+        projects_and_groups:
+          {group}/*:
+            enforce_group_members: true
+            group_members:
+              {users[0]}:
+                access_level: 50
+            group_shared_with:
+              {groups[0]}:
+                group_access_level: 30
+        """
+
+        run_gitlabform(remove_users, group)
+
+        members = gitlab.get_group_members(group)
+        assert len(members) == no_of_members_before
+
+        shared_with = gitlab.get_group_shared_with(group)
+        assert len(shared_with) == no_of_shared_with_before - 1
+
+        assert [sw["group_name"] for sw in shared_with] == [groups[0]]
+
+    def test__not_remove_groups_with_enforce_false(
+        self, gitlab, group, users, groups, one_owner
+    ):
+
+        no_of_members_before = len(gitlab.get_group_members(group))
+        no_of_shared_with_before = len(gitlab.get_group_shared_with(group))
+
+        setups = [
+            # flag explicitly set to false
+            f"""
+            projects_and_groups:
+              {group}/*:
+                enforce_group_members: false
+                group_members:
+                  {users[0]}:
+                    access_level: 50
+                group_shared_with:
+                  {groups[0]}:
+                    group_access_level: 30
+            """,
+            # flag not set at all (but the default is false)
+            f"""
+            projects_and_groups:
+              {group}/*:
+                group_members:
+                  {users[0]}:
+                    access_level: 50
+                group_shared_with:
+                  {groups[0]}:
+                    group_access_level: 30
+            """,
+        ]
+        for setup in setups:
+            run_gitlabform(setup, group)
+
+            members = gitlab.get_group_members(group)
+            assert len(members) == no_of_members_before
+
+            members_usernames = {member["username"] for member in members}
+            assert members_usernames == {
+                f"{users[0]}",
+            }
+
+            shared_with = gitlab.get_group_shared_with(group)
+            assert len(shared_with) == no_of_shared_with_before
+
+    def test__change_group_access(self, gitlab, group, groups, users, one_owner):
+
+        change_some_users_access = f"""
+        projects_and_groups:
+          {group}/*:
+            group_members:
+              {users[0]}:
+                access_level: 50
+            group_shared_with:
+              {groups[0]}:
+                group_access_level: 30
+              {groups[1]}:
+                group_access_level: 50
+        """
+
+        run_gitlabform(change_some_users_access, group)
+
+        shared_with = gitlab.get_group_shared_with(group)
+        for shared_with_group in shared_with:
+            if shared_with_group["group_name"] == f"{groups[0]}":
+                assert shared_with_group["group_access_level"] == 30
+            if shared_with_group["group_name"] == f"{groups[1]}":
+                assert shared_with_group["group_access_level"] == 50
+
+    def test__remove_all(self, gitlab, group, users, one_owner):
+        no_shared_with = f"""
+        projects_and_groups:
+          {group}/*:
+            enforce_group_members: true
+            group_members:
+              {users[0]}:
+                access_level: 50
+            group_shared_with: []
+        """
+
+        run_gitlabform(no_shared_with, group)
+
+        shared_with = gitlab.get_group_shared_with(group)
+        assert len(shared_with) == 0


### PR DESCRIPTION
Hi,

This PR adds a new `group_shared_with` group level config, and code to maintain the list of groups that a group is shared with. It also includes acceptance tests, which pass (at least for me). The code is very much based on the code that maintains group user access.

I believe this fixes #150.

Please review the code, I'm happy to make any changes that might be required.

Many thanks,
Andrew Wilkinson (on behalf of Ocado Technology)
