### PR TITLE
fix typo in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ Thanks to [@ss7548](https://github.com/ss7548) and [@houres](https://github.com/
 
 (Compared to v1)
 
-* **New config syntax (breaking change).** All 3 levels under a common key `groups_and_projects`. It should contain a dict, where common config is under a special `"*"` key, group configs under keys like `group/*` and project configs under keys like `group/project`. This will allow introducing pattern matching in these keys and introducing support for multiple config files in the future releases. Partially implements [#138](https://github.com/egnyte/gitlabform/pull/138).
+* **New config syntax (breaking change).** All 3 levels under a common key `projects_and_groups`. It should contain a dict, where common config is under a special `"*"` key, group configs under keys like `group/*` and project configs under keys like `group/project`. This will allow introducing pattern matching in these keys and introducing support for multiple config files in the future releases. Partially implements [#138](https://github.com/egnyte/gitlabform/pull/138).
 
 * **Introduce config versioning (breaking change).** ...or rather a change to avoid breakage. New major releases of GitLabForm starting with v2 will look for `config_version` key in the config file. If it doesn't exist, or the version does not match expected then the app will exit to avoid applying unexpected configuration and allowing the user to update the configuration.
 

--- a/docs/FEATURES_DESIGN.md
+++ b/docs/FEATURES_DESIGN.md
@@ -10,7 +10,7 @@ You want to configure all your GitLab instance projects to have JIRA integration
 ticket ids shown as links to JIRA in the web UI, but you DON'T want the integration that enables to close JIRA
 tickets from MRs that have "closes <ticket_id>" in their description, so you do this:
 ```yaml
-groups_and_projects:
+projects_and_groups:
   # common settings for ALL projects in ALL groups
   "*":
     services:
@@ -52,7 +52,7 @@ You want to add a default README file to all your projects that contains a conve
 in Confluence. So you add this to your config:
 
 ```yaml
-groups_and_projects:
+projects_and_groups:
   "*":
     files:
       "README.md":


### PR DESCRIPTION
There seems to be some confusion between `projects_and_groups` and `groups_and_projects`