### PR TITLE
Switch to using group path rather than group name when sharing groups

### DIFF
--- a/gitlabform/gitlab/groups.py
+++ b/gitlabform/gitlab/groups.py
@@ -34,12 +34,14 @@ class GitLabGroups(GitLabCore):
                     return group
             raise NotFoundException
 
-    def create_group(self, name, path, visibility="private"):
+    def create_group(self, name, path, parent_id=None, visibility="private"):
         data = {
             "name": name,
             "path": path,
             "visibility": visibility,
         }
+        if parent_id is not None:
+            data["parent_id"] = parent_id
         return self._make_requests_to_api(
             "groups", data=data, method="POST", expected_codes=201
         )

--- a/gitlabform/gitlabform/test/__init__.py
+++ b/gitlabform/gitlabform/test/__init__.py
@@ -59,8 +59,8 @@ def get_gitlab():
     return gl
 
 
-def create_group(group_name):
-    gl.create_group(group_name, group_name)
+def create_group(group_name, parent_id=None):
+    gl.create_group(group_name, group_name, parent_id)
 
 
 def create_groups(group_base_name, no_of_groups):

--- a/gitlabform/gitlabform/test/conftest.py
+++ b/gitlabform/gitlabform/test/conftest.py
@@ -43,6 +43,19 @@ def other_group():
 
 
 @pytest.fixture(scope="class")
+def sub_group(group):
+    gl = get_gitlab()
+    parent_id = gl.get_group_id_case_insensitive(group)
+    group_name = get_random_name()
+    create_group(group_name, parent_id)
+
+    yield group + "/" + group_name
+
+    gl = get_gitlab()
+    gl.delete_group(group + "/" + group_name)
+
+
+@pytest.fixture(scope="class")
 def project(group):
     project_name = get_random_name()
     create_project(group, project_name)


### PR DESCRIPTION
Switch to using group path rather than group name when sharing groups with other groups. This allows subgroups to be shared with.

I wasn't able to reproduce #236, but this might fix it (and is probably a good idea anyway!)

Thanks,
Andrew Wilkinson (on behalf of Ocado Technology)