### PR TITLE
Update get_groups_from_project to return groups keyed by group_path

### DIFF
--- a/gitlabform/gitlab/projects.py
+++ b/gitlabform/gitlab/projects.py
@@ -427,7 +427,7 @@ class GitLabProjects(GitLabCore):
         # it will return {group_name: {...api info about group_name...}, ...}
         groups = {}
         for group in project_info["shared_with_groups"]:
-            groups[group["group_name"]] = group
+            groups[group["group_full_path"]] = group
 
         return groups
 


### PR DESCRIPTION
Currently this api returns groups keyed by their name. This api is only used in MembersProcessor where we try and index it by the group path, so the groups are never found and deleted and readded on every run. This change switches to key them by path.

Fixes #240.
