### PR TITLE
Cleaner output calls, especially verbose/debug

### DIFF
--- a/gitlabform/configuration/case_insensitivity.py
+++ b/gitlabform/configuration/case_insensitivity.py
@@ -1,11 +1,9 @@
-import logging
-import cli_ui
+from logging import debug
+from cli_ui import fatal
 
 from gitlabform import EXIT_INVALID_INPUT
 from gitlabform.configuration.core import KeyNotFoundException
 from gitlabform.configuration.projects_and_groups import ConfigurationProjectsAndGroups
-
-logger = logging.getLogger(__name__)
 
 
 class ConfigurationCaseInsensitiveProjectsAndGroups(ConfigurationProjectsAndGroups):
@@ -85,7 +83,7 @@ class ConfigurationCaseInsensitiveProjectsAndGroups(ConfigurationProjectsAndGrou
             if self.get(path, 0):
                 almost_duplicates = self._find_almost_duplicates(path)
                 if almost_duplicates:
-                    cli_ui.fatal(
+                    fatal(
                         f"There are almost duplicates in the keys of {path} - they differ only in case.\n"
                         f"They are: {', '.join(almost_duplicates)}\n"
                         f"This is not allowed as we ignore the case for group and project names.",

--- a/gitlabform/configuration/core.py
+++ b/gitlabform/configuration/core.py
@@ -1,13 +1,13 @@
 import os
-import logging
 import textwrap
 
-import cli_ui
+from logging import debug
+from cli_ui import debug as verbose
+from cli_ui import fatal
+
 import yaml
 from pathlib import Path
-
 from mergedeep import merge
-
 from gitlabform import EXIT_INVALID_INPUT
 
 
@@ -19,14 +19,14 @@ class ConfigurationCore:
     def __init__(self, config_path=None, config_string=None):
 
         if config_path and config_string:
-            cli_ui.fatal(
+            fatal(
                 "Please initialize with either config_path or config_string, not both.",
                 exit_code=EXIT_INVALID_INPUT,
             )
 
         try:
             if config_string:
-                cli_ui.debug("Reading config from provided string.")
+                verbose("Reading config from provided string.")
                 self.config = yaml.safe_load(textwrap.dedent(config_string))
                 self.config_dir = "."
             else:  # maybe config_path
@@ -43,17 +43,17 @@ class ConfigurationCore:
                     # provided points to config.yml in the app current working dir
                     config_path = os.path.join(os.getcwd(), "config.yml")
 
-                cli_ui.debug(f"Reading config from file: {config_path}")
+                verbose(f"Reading config from file: {config_path}")
 
                 with open(config_path, "r") as ymlfile:
                     self.config = yaml.safe_load(ymlfile)
-                    logging.debug("Config parsed successfully as YAML.")
+                    debug("Config parsed successfully as YAML.")
 
                 # we need config path for accessing files for relative paths
                 self.config_dir = os.path.dirname(config_path)
 
                 if self.config.get("example_config"):
-                    cli_ui.fatal(
+                    fatal(
                         "Example config detected, aborting.\n"
                         "Haven't you forgotten to use `-c <config_file>` parameter?\n"
                         "If you created your config based on the example config.yml,"
@@ -62,7 +62,7 @@ class ConfigurationCore:
                     )
 
                 if self.config.get("config_version", 1) != 2:
-                    cli_ui.fatal(
+                    fatal(
                         "This version of GitLabForm requires 'config_version: 2' entry in the config.\n"
                         "This ensures that when the application behavior changes in a backward incompatible way,"
                         " you won't apply unexpected configuration to your GitLab instance.\n"

--- a/gitlabform/configuration/groups.py
+++ b/gitlabform/configuration/groups.py
@@ -1,8 +1,6 @@
-import logging
+from logging import debug
 
 from gitlabform.configuration.core import ConfigurationCore
-
-logger = logging.getLogger(__name__)
 
 
 class ConfigurationGroups(ConfigurationCore):
@@ -29,10 +27,10 @@ class ConfigurationGroups(ConfigurationCore):
         """
 
         common_config = self.get_common_config()
-        logging.debug("Common config: %s" % common_config)
+        debug("Common config: %s" % common_config)
 
         group_config = self.get_group_config(group)
-        logging.debug("Group config: %s" % group_config)
+        debug("Group config: %s" % group_config)
 
         if not group_config and not common_config:
             return {}
@@ -62,21 +60,19 @@ class ConfigurationGroups(ConfigurationCore):
         for element in elements:
             if not last_element:
                 effective_config = self.get_group_config(element)
-                logging.debug(
-                    "First level config for '%s': %s" % (element, effective_config)
-                )
+                debug("First level config for '%s': %s" % (element, effective_config))
                 last_element = element
             else:
                 next_level_subgroup = last_element + "/" + element
                 next_level_subgroup_config = self.get_group_config(next_level_subgroup)
-                logging.debug(
+                debug(
                     "Config for '%s': %s"
                     % (next_level_subgroup, next_level_subgroup_config)
                 )
                 effective_config = self.merge_configs(
                     effective_config, next_level_subgroup_config
                 )
-                logging.debug(
+                debug(
                     "Merged previous level config for '%s' with config for '%s': %s"
                     % (last_element, next_level_subgroup, effective_config)
                 )

--- a/gitlabform/configuration/projects_and_groups.py
+++ b/gitlabform/configuration/projects_and_groups.py
@@ -1,8 +1,6 @@
-import logging
+from logging import debug
 
 from gitlabform.configuration.groups import ConfigurationGroups
-
-logger = logging.getLogger(__name__)
 
 
 class ConfigurationProjectsAndGroups(ConfigurationGroups):
@@ -30,27 +28,23 @@ class ConfigurationProjectsAndGroups(ConfigurationGroups):
         """
 
         common_config = self.get_common_config()
-        logging.debug("Common config: %s" % common_config)
+        debug("Common config: %s" % common_config)
 
         group, project = group_and_project.rsplit("/", 1)
         if "/" in group:
             group_config = self.get_effective_subgroup_config(group)
         else:
             group_config = self.get_group_config(group)
-        logging.debug("Effective group/subgroup config: %s" % group_config)
+        debug("Effective group/subgroup config: %s" % group_config)
 
         project_config = self.get_project_config(group_and_project)
-        logging.debug("Project config: %s" % project_config)
+        debug("Project config: %s" % project_config)
 
         common_and_group_config = self.merge_configs(common_config, group_config)
-        logging.debug(
-            "Effective config common+group/subgroup: %s" % common_and_group_config
-        )
+        debug("Effective config common+group/subgroup: %s" % common_and_group_config)
 
         effective_config = self.merge_configs(common_and_group_config, project_config)
-        logging.debug(
-            "Effective config common+group/subgroup+project: %s" % effective_config
-        )
+        debug("Effective config common+group/subgroup+project: %s" % effective_config)
 
         return effective_config
 

--- a/gitlabform/core.py
+++ b/gitlabform/core.py
@@ -1,9 +1,12 @@
 import argparse
 import logging.config
+import logging
 import sys
 import textwrap
 import traceback
 
+from logging import debug
+from cli_ui import warning, fatal
 import cli_ui
 
 from gitlabform import EXIT_INVALID_INPUT, EXIT_PROCESSING_ERROR
@@ -81,7 +84,7 @@ class GitLabForm(object):
                 sys.exit(0)
 
             if not self.project_or_group:
-                cli_ui.fatal(
+                fatal(
                     "project_or_group parameter is required.",
                     exit_code=EXIT_INVALID_INPUT,
                 )
@@ -243,9 +246,9 @@ class GitLabForm(object):
 
     def configure_output(self, tests=False):
 
-        # normal mode - print cli_ui.info+
-        # verbose mode - print cli_ui.*
-        # debug / tests mode - like above + logging.debug
+        # normal mode - print cli_ui.* except debug as verbose
+        # verbose mode - print all cli_ui.*, including debug as verbose
+        # debug / tests mode - like above + (logging.)debug
 
         logging.basicConfig()
 
@@ -280,17 +283,17 @@ class GitLabForm(object):
             configuration = gitlab.get_configuration()
             return gitlab, configuration
         except ConfigFileNotFoundException as e:
-            cli_ui.fatal(
+            fatal(
                 f"Config file not found at: {e}",
                 exit_code=EXIT_INVALID_INPUT,
             )
         except ConfigInvalidException as e:
-            cli_ui.fatal(
+            fatal(
                 f"Invalid config:\n{e.underlying}",
                 exit_code=EXIT_INVALID_INPUT,
             )
         except TestRequestFailedException as e:
-            cli_ui.fatal(
+            fatal(
                 f"GitLab test request failed:\n{e.underlying}",
                 exit_code=EXIT_PROCESSING_ERROR,
             )
@@ -354,14 +357,14 @@ class GitLabForm(object):
 
                 if self.terminate_after_error:
                     effective_configuration.write_to_file()
-                    cli_ui.fatal(
+                    fatal(
                         message,
                         exit_code=EXIT_PROCESSING_ERROR,
                     )
                 else:
-                    cli_ui.warning(message)
+                    warning(message)
             finally:
-                logging.debug(
+                debug(
                     f"@ ({group_number}/{len(groups_with_non_empty_configs)}) FINISHED Processing group: {group}"
                 )
 
@@ -416,16 +419,16 @@ class GitLabForm(object):
 
                 if self.terminate_after_error:
                     effective_configuration.write_to_file()
-                    cli_ui.fatal(
+                    fatal(
                         message,
                         exit_code=EXIT_PROCESSING_ERROR,
                     )
                 else:
-                    cli_ui.warning(message)
+                    warning(message)
 
             finally:
 
-                logging.debug(
+                debug(
                     f"* ({project_number}/{len(projects_with_non_empty_configs)})"
                     f" FINISHED Processing project: {project_and_group}",
                 )

--- a/gitlabform/filter.py
+++ b/gitlabform/filter.py
@@ -1,4 +1,4 @@
-import cli_ui
+from cli_ui import fatal
 
 from gitlabform import EXIT_INVALID_INPUT
 
@@ -27,7 +27,7 @@ class NonEmptyConfigsProvider(object):
         self.project_processors = project_processors
 
         if not self.configuration.get("projects_and_groups", {}):
-            cli_ui.fatal(
+            fatal(
                 "Configuration has to contain non-empty 'projects_and_groups' key.",
                 exit_code=EXIT_INVALID_INPUT,
             )

--- a/gitlabform/gitlab/core.py
+++ b/gitlabform/gitlab/core.py
@@ -1,7 +1,7 @@
 import json
-import logging
+from logging import debug
+from cli_ui import debug as verbose
 
-import cli_ui
 import pkg_resources
 import requests
 import os
@@ -52,7 +52,7 @@ class GitLabCore:
 
         try:
             version = self._make_requests_to_api("version")
-            cli_ui.debug(
+            verbose(
                 f"Connected to GitLab version: {version['version']} ({version['revision']})"
             )
             self.version = version["version"]
@@ -186,7 +186,7 @@ class GitLabCore:
             + "/api/v4/"
             + self._format_with_url_encoding(path_as_format_string, args)
         )
-        logging.debug(
+        debug(
             "url = %s , method = %s , data = %s, json = %s",
             url,
             method,
@@ -203,13 +203,13 @@ class GitLabCore:
             )
         else:
             response = self.session.request(method, url, timeout=self.timeout)
-        logging.debug("response code=%s" % response.status_code)
+        debug("response code=%s" % response.status_code)
 
         if response.status_code in expected_codes:
             # if we accept error responses then they will likely not contain a JSON body
             # so fake it to fix further calls to response.json()
             if response.status_code == 204 or (400 <= response.status_code <= 499):
-                logging.debug("faking response body to be {}")
+                debug("faking response body to be {}")
                 response.json = lambda: {}
         else:
             if response.status_code == 404:
@@ -225,7 +225,7 @@ class GitLabCore:
                     response.status_code,
                 )
 
-        logging.debug("response json=%s" % json.dumps(response.json(), sort_keys=True))
+        debug("response json=%s" % json.dumps(response.json(), sort_keys=True))
         return response
 
     @staticmethod

--- a/gitlabform/input.py
+++ b/gitlabform/input.py
@@ -1,4 +1,4 @@
-import cli_ui
+from cli_ui import fatal
 
 from gitlabform import EXIT_INVALID_INPUT
 from gitlabform.gitlab.core import NotFoundException
@@ -49,7 +49,7 @@ class GroupsAndProjectsProvider:
                     group = self.gitlab.get_group_case_insensitive(group)
                     effective_groups_proper_case.append(group["full_path"])
                 except NotFoundException:
-                    cli_ui.fatal(
+                    fatal(
                         f"Configuration contains group {group} but it cannot be found in GitLab!",
                         exit_code=EXIT_INVALID_INPUT,
                     )

--- a/gitlabform/output.py
+++ b/gitlabform/output.py
@@ -1,6 +1,7 @@
-import logging
+from logging import debug
+from cli_ui import debug as verbose
+from cli_ui import fatal
 
-import cli_ui
 import yaml
 
 from gitlabform import EXIT_INVALID_INPUT, EXIT_PROCESSING_ERROR
@@ -17,11 +18,11 @@ class EffectiveConfiguration:
         if output_file:
             try:
                 self.output_file = open(output_file, "w")
-                logging.debug(
+                debug(
                     f"Opened file {self.output_file} to write the effective configs to."
                 )
             except Exception as e:
-                cli_ui.fatal(
+                fatal(
                     f"Error when trying to open {self.output_file} to write the effective configs to: {e}",
                     exit_code=EXIT_INVALID_INPUT,
                 )
@@ -38,7 +39,7 @@ class EffectiveConfiguration:
         self, project_or_group: str, configuration_name: str, configuration: dict
     ):
         if self.output_file:
-            cli_ui.debug(f"Adding effective configuration for {configuration_name}.")
+            verbose(f"Adding effective configuration for {configuration_name}.")
             self.config[project_or_group][configuration_name] = configuration
 
     def write_to_file(self):
@@ -51,7 +52,7 @@ class EffectiveConfiguration:
                 self.output_file.write(yaml_configuration)
                 self.output_file.close()
             except Exception as e:
-                cli_ui.fatal(
+                fatal(
                     f"Error when trying to write or close {self.output_file}: {e}",
                     exit_code=EXIT_PROCESSING_ERROR,
                 )

--- a/gitlabform/processors/abstract_processor.py
+++ b/gitlabform/processors/abstract_processor.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-import cli_ui
+from cli_ui import debug as verbose
 
 from gitlabform.gitlab import GitLab
 from gitlabform.output import EffectiveConfiguration
@@ -22,7 +22,7 @@ class AbstractProcessor(ABC):
     ):
         if self.configuration_name in configuration:
             if configuration.get(f"{self.configuration_name}|skip"):
-                cli_ui.debug(
+                verbose(
                     f"Skipping {self.configuration_name} - explicitly configured to do so."
                 )
                 return
@@ -30,19 +30,19 @@ class AbstractProcessor(ABC):
                 configuration.get("project|archive")
                 and self.configuration_name != "project"
             ):
-                cli_ui.debug(
+                verbose(
                     f"Skipping {self.configuration_name} - it is configured to be archived."
                 )
                 return
 
             if dry_run:
-                cli_ui.debug(f"Processing {self.configuration_name} in dry-run mode.")
+                verbose(f"Processing {self.configuration_name} in dry-run mode.")
                 self._print_diff(
                     project_or_project_and_group,
                     configuration.get(self.configuration_name),
                 )
             else:
-                cli_ui.debug(f"Processing {self.configuration_name}")
+                verbose(f"Processing {self.configuration_name}")
                 self._process_configuration(project_or_project_and_group, configuration)
 
             effective_configuration.add_configuration(
@@ -51,7 +51,7 @@ class AbstractProcessor(ABC):
                 configuration.get(self.configuration_name),
             )
         else:
-            cli_ui.debug(f"Skipping {self.configuration_name} - not in config.")
+            verbose(f"Skipping {self.configuration_name} - not in config.")
 
     @abstractmethod
     def _process_configuration(
@@ -60,6 +60,4 @@ class AbstractProcessor(ABC):
         pass
 
     def _print_diff(self, project_or_project_and_group: str, configuration_to_process):
-        cli_ui.debug(
-            f"Diffing for {self.configuration_name} section is not supported yet"
-        )
+        verbose(f"Diffing for {self.configuration_name} section is not supported yet")

--- a/gitlabform/processors/group/group_members_processor.py
+++ b/gitlabform/processors/group/group_members_processor.py
@@ -1,6 +1,5 @@
-import logging
-
-import cli_ui
+from logging import debug
+from cli_ui import fatal
 
 from gitlabform import EXIT_INVALID_INPUT
 from gitlabform.gitlab import GitLab, AccessLevel
@@ -17,7 +16,7 @@ class GroupMembersProcessor(AbstractProcessor):
 
             # group users before by username
             users_before = self.gitlab.get_group_members(group)
-            logging.debug("Group members BEFORE: %s", users_before)
+            debug("Group members BEFORE: %s", users_before)
             users_before_by_username = dict()
             for user in users_before:
                 users_before_by_username[user["username"]] = user
@@ -33,7 +32,7 @@ class GroupMembersProcessor(AbstractProcessor):
                 AccessLevel.OWNER.value not in users_to_set_by_access_level.keys()
                 and configuration.get("enforce_group_members")
             ):
-                cli_ui.fatal(
+                fatal(
                     "With 'enforce_group_members' flag you cannot have no Owners (access_level = 50) in your "
                     " group members config. GitLab requires at least 1 Owner per group.",
                     exit_code=EXIT_INVALID_INPUT,
@@ -69,12 +68,12 @@ class GroupMembersProcessor(AbstractProcessor):
                             access_level_before == access_level_to_set
                             and expires_at_before == expires_at_to_set
                         ):
-                            logging.debug(
+                            debug(
                                 "Nothing to change for user '%s' - same config now as to set.",
                                 user,
                             )
                         else:
-                            logging.debug(
+                            debug(
                                 "Re-adding user '%s' to change their access level or expires at.",
                                 user,
                             )
@@ -86,9 +85,7 @@ class GroupMembersProcessor(AbstractProcessor):
                             )
 
                     else:
-                        logging.debug(
-                            "Adding user '%s' who previously was not a member.", user
-                        )
+                        debug("Adding user '%s' who previously was not a member.", user)
                         self.gitlab.add_member_to_group(
                             group, user, access_level_to_set, expires_at_to_set
                         )
@@ -100,20 +97,18 @@ class GroupMembersProcessor(AbstractProcessor):
                     [user["username"] for user in users_before]
                 ) - set(users_to_set_by_username.keys())
                 for user in users_not_configured:
-                    logging.debug(
+                    debug(
                         "Removing user '%s' who is not configured to be a member.", user
                     )
                     self.gitlab.remove_member_from_group(group, user)
             else:
-                logging.debug("Not enforcing group members.")
+                debug("Not enforcing group members.")
 
-            logging.debug(
-                "Group members AFTER: %s", self.gitlab.get_group_members(group)
-            )
+            debug("Group members AFTER: %s", self.gitlab.get_group_members(group))
 
         else:
 
-            cli_ui.fatal(
+            fatal(
                 "You cannot configure a group to have no members. GitLab requires a group "
                 " to contain at least 1 member who is an Owner (access_level = 50).",
                 exit_code=EXIT_INVALID_INPUT,

--- a/gitlabform/processors/group/group_secret_variables_processor.py
+++ b/gitlabform/processors/group/group_secret_variables_processor.py
@@ -1,6 +1,6 @@
-import logging
-
-import cli_ui
+from logging import debug
+from cli_ui import debug as verbose
+from cli_ui import warning
 
 from gitlabform.gitlab import GitLab
 from gitlabform.gitlab.core import NotFoundException
@@ -12,7 +12,7 @@ class GroupSecretVariablesProcessor(AbstractProcessor):
         super().__init__("group_secret_variables", gitlab)
 
     def _process_configuration(self, group: str, configuration: dict):
-        logging.debug(
+        debug(
             "Group secret variables BEFORE: %s",
             self.gitlab.get_group_secret_variables(group),
         )
@@ -22,14 +22,14 @@ class GroupSecretVariablesProcessor(AbstractProcessor):
             if "delete" in configuration["group_secret_variables"][secret_variable]:
                 key = configuration["group_secret_variables"][secret_variable]["key"]
                 if configuration["group_secret_variables"][secret_variable]["delete"]:
-                    cli_ui.debug(f"Deleting {secret_variable}: {key} in group {group}")
+                    verbose(f"Deleting {secret_variable}: {key} in group {group}")
                     try:
                         self.gitlab.delete_group_secret_variable(group, key)
                     except:
-                        cli_ui.info(f"Could not delete variable {key} in group {group}")
+                        warning(f"Could not delete variable {key} in group {group}")
                     continue
 
-            cli_ui.debug(f"Setting group secret variable: {secret_variable}")
+            verbose(f"Setting group secret variable: {secret_variable}")
             try:
                 self.gitlab.put_group_secret_variable(
                     group, configuration["group_secret_variables"][secret_variable]
@@ -39,7 +39,7 @@ class GroupSecretVariablesProcessor(AbstractProcessor):
                     group, configuration["group_secret_variables"][secret_variable]
                 )
 
-        logging.debug(
+        debug(
             "Groups secret variables AFTER: %s",
             self.gitlab.get_group_secret_variables(group),
         )

--- a/gitlabform/processors/group/group_settings_processor.py
+++ b/gitlabform/processors/group/group_settings_processor.py
@@ -1,6 +1,5 @@
-import logging
-
-import cli_ui
+from logging import debug
+from cli_ui import debug as verbose
 
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
@@ -12,9 +11,7 @@ class GroupSettingsProcessor(AbstractProcessor):
 
     def _process_configuration(self, group: str, configuration: dict):
         group_settings = configuration["group_settings"]
-        logging.debug(
-            "Group settings BEFORE: %s", self.gitlab.get_group_settings(group)
-        )
-        cli_ui.debug(f"Setting group settings: {group_settings}")
+        debug("Group settings BEFORE: %s", self.gitlab.get_group_settings(group))
+        verbose(f"Setting group settings: {group_settings}")
         self.gitlab.put_group_settings(group, group_settings)
-        logging.debug("Group settings AFTER: %s", self.gitlab.get_group_settings(group))
+        debug("Group settings AFTER: %s", self.gitlab.get_group_settings(group))

--- a/gitlabform/processors/group/group_shared_with_processor.py
+++ b/gitlabform/processors/group/group_shared_with_processor.py
@@ -1,4 +1,4 @@
-import logging
+from logging import debug
 
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
@@ -17,7 +17,7 @@ class GroupSharedWithProcessor(AbstractProcessor):
         groups_before = self.gitlab.get_group_case_insensitive(group)[
             "shared_with_groups"
         ]
-        logging.debug("Group shared with BEFORE: %s", groups_before)
+        debug("Group shared with BEFORE: %s", groups_before)
 
         groups_before_by_group_path = dict()
         for share_details in groups_before:
@@ -50,12 +50,12 @@ class GroupSharedWithProcessor(AbstractProcessor):
                     group_access_before == group_access_to_set
                     and expires_at_before == expires_at_to_set
                 ):
-                    logging.debug(
+                    debug(
                         "Nothing to change for group '%s' - same config now as to set.",
                         share_with_group_path,
                     )
                 else:
-                    logging.debug(
+                    debug(
                         "Re-adding group '%s' to change their access level or expires at.",
                         share_with_group_path,
                     )
@@ -70,7 +70,7 @@ class GroupSharedWithProcessor(AbstractProcessor):
                     )
 
             else:
-                logging.debug(
+                debug(
                     "Adding group '%s' who previously was not a member.",
                     share_with_group_path,
                 )
@@ -84,14 +84,12 @@ class GroupSharedWithProcessor(AbstractProcessor):
                 groups_to_set_by_group_path
             )
             for group_path in groups_not_configured:
-                logging.debug(
+                debug(
                     "Removing group '%s' who is not configured to be a member.",
                     group_path,
                 )
                 self.gitlab.remove_share_from_group(group, group_path)
         else:
-            logging.debug("Not enforcing group members.")
+            debug("Not enforcing group members.")
 
-        logging.debug(
-            "Group shared with AFTER: %s", self.gitlab.get_group_members(group)
-        )
+        debug("Group shared with AFTER: %s", self.gitlab.get_group_members(group))

--- a/gitlabform/processors/project/deploy_keys_processor.py
+++ b/gitlabform/processors/project/deploy_keys_processor.py
@@ -1,6 +1,5 @@
-import logging
-
-import cli_ui
+from logging import debug
+from cli_ui import debug as verbose
 
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
@@ -11,14 +10,10 @@ class DeployKeysProcessor(AbstractProcessor):
         super().__init__("deploy_keys", gitlab)
 
     def _process_configuration(self, project_and_group: str, configuration: dict):
-        logging.debug(
-            "Deploy keys BEFORE: %s", self.gitlab.get_deploy_keys(project_and_group)
-        )
+        debug("Deploy keys BEFORE: %s", self.gitlab.get_deploy_keys(project_and_group))
         for deploy_key in sorted(configuration["deploy_keys"]):
-            cli_ui.debug(f"Setting deploy key: {deploy_key}")
+            verbose(f"Setting deploy key: {deploy_key}")
             self.gitlab.post_deploy_key(
                 project_and_group, configuration["deploy_keys"][deploy_key]
             )
-        logging.debug(
-            "Deploy keys AFTER: %s", self.gitlab.get_deploy_keys(project_and_group)
-        )
+        debug("Deploy keys AFTER: %s", self.gitlab.get_deploy_keys(project_and_group))

--- a/gitlabform/processors/project/files_processor.py
+++ b/gitlabform/processors/project/files_processor.py
@@ -1,9 +1,11 @@
-import logging
 import os
 import re
 from pathlib import Path
 
-import cli_ui
+from logging import debug
+from cli_ui import debug as verbose
+from cli_ui import warning, fatal
+
 from jinja2 import Environment, FileSystemLoader
 
 from gitlabform import EXIT_INVALID_INPUT
@@ -23,10 +25,10 @@ class FilesProcessor(AbstractProcessor):
 
     def _process_configuration(self, project_and_group: str, configuration: dict):
         for file in sorted(configuration["files"]):
-            logging.debug("Processing file '%s'...", file)
+            debug("Processing file '%s'...", file)
 
             if configuration.get("files|" + file + "|skip"):
-                logging.debug("Skipping file '%s'", file)
+                debug("Skipping file '%s'", file)
                 continue
 
             if configuration["files"][file]["branches"] == "all":
@@ -46,20 +48,20 @@ class FilesProcessor(AbstractProcessor):
                     else:
                         message = f"! Branch '{branch}' not found, not processing file '{file}' in it"
                         if self.strict:
-                            cli_ui.fatal(
+                            fatal(
                                 message,
                                 exit_code=EXIT_INVALID_INPUT,
                             )
                         else:
-                            cli_ui.warning(message)
+                            warning(message)
 
             for branch in branches:
-                cli_ui.debug(f"Processing file '{file}' in branch '{branch}'")
+                verbose(f"Processing file '{file}' in branch '{branch}'")
 
                 if configuration.get(
                     "files|" + file + "|content"
                 ) and configuration.get("files|" + file + "|file"):
-                    cli_ui.fatal(
+                    fatal(
                         f"File '{file}' in '{project_and_group}' has both `content` and `file` set - "
                         "use only one of these keys.",
                         exit_code=EXIT_INVALID_INPUT,
@@ -67,7 +69,7 @@ class FilesProcessor(AbstractProcessor):
 
                 # unprotect protected branch temporarily for operations below
                 if configuration.get("branches|" + branch + "|protected"):
-                    logging.debug(
+                    debug(
                         "> Temporarily unprotecting the branch for managing files in it..."
                     )
                     self.branch_protector.unprotect_branch(project_and_group, branch)
@@ -75,7 +77,7 @@ class FilesProcessor(AbstractProcessor):
                 if configuration.get("files|" + file + "|delete"):
                     try:
                         self.gitlab.get_file(project_and_group, branch, file)
-                        logging.debug("Deleting file '%s' in branch '%s'", file, branch)
+                        debug("Deleting file '%s' in branch '%s'", file, branch)
                         self.gitlab.delete_file(
                             project_and_group,
                             branch,
@@ -86,7 +88,7 @@ class FilesProcessor(AbstractProcessor):
                             ),
                         )
                     except NotFoundException:
-                        logging.debug(
+                        debug(
                             "Not deleting file '%s' in branch '%s' (already doesn't exist)",
                             file,
                             branch,
@@ -125,9 +127,7 @@ class FilesProcessor(AbstractProcessor):
                         )
                         if current_content != new_content:
                             if configuration.get("files|" + file + "|overwrite"):
-                                logging.debug(
-                                    "Changing file '%s' in branch '%s'", file, branch
-                                )
+                                debug("Changing file '%s' in branch '%s'", file, branch)
                                 self.gitlab.set_file(
                                     project_and_group,
                                     branch,
@@ -139,20 +139,20 @@ class FilesProcessor(AbstractProcessor):
                                     ),
                                 )
                             else:
-                                logging.debug(
+                                debug(
                                     "Not changing file '%s' in branch '%s' - overwrite flag not set.",
                                     file,
                                     branch,
                                 )
                         else:
-                            logging.debug(
+                            debug(
                                 "Not changing file '%s' in branch '%s' - it's content is already"
                                 " as provided)",
                                 file,
                                 branch,
                             )
                     except NotFoundException:
-                        logging.debug("Creating file '%s' in branch '%s'", file, branch)
+                        debug("Creating file '%s' in branch '%s'", file, branch)
                         self.gitlab.add_file(
                             project_and_group,
                             branch,
@@ -165,14 +165,12 @@ class FilesProcessor(AbstractProcessor):
 
                 # protect branch back after above operations
                 if configuration.get("branches|" + branch + "|protected"):
-                    logging.debug("> Protecting the branch again.")
+                    debug("> Protecting the branch again.")
                     self.branch_protector.protect_branch(
                         project_and_group, configuration, branch
                     )
                 if configuration.get("files|" + file + "|only_first_branch"):
-                    cli_ui.debug(
-                        "Skipping other branches for this file, as configured."
-                    )
+                    verbose("Skipping other branches for this file, as configured.")
                     break
 
     def get_file_content_as_template(self, template, project_and_group, **kwargs):

--- a/gitlabform/processors/project/hooks_processor.py
+++ b/gitlabform/processors/project/hooks_processor.py
@@ -1,4 +1,4 @@
-import logging
+from logging import debug
 
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
@@ -14,21 +14,19 @@ class HooksProcessor(AbstractProcessor):
             if configuration.get("hooks|" + hook + "|delete"):
                 hook_id = self.gitlab.get_hook_id(project_and_group, hook)
                 if hook_id:
-                    logging.debug("Deleting hook '%s'", hook)
+                    debug("Deleting hook '%s'", hook)
                     self.gitlab.delete_hook(project_and_group, hook_id)
                 else:
-                    logging.debug(
-                        "Not deleting hook '%s', because it doesn't exist", hook
-                    )
+                    debug("Not deleting hook '%s', because it doesn't exist", hook)
             else:
                 hook_id = self.gitlab.get_hook_id(project_and_group, hook)
                 if hook_id:
-                    logging.debug("Changing existing hook '%s'", hook)
+                    debug("Changing existing hook '%s'", hook)
                     self.gitlab.put_hook(
                         project_and_group, hook_id, hook, configuration["hooks"][hook]
                     )
                 else:
-                    logging.debug("Creating hook '%s'", hook)
+                    debug("Creating hook '%s'", hook)
                     self.gitlab.post_hook(
                         project_and_group, hook, configuration["hooks"][hook]
                     )

--- a/gitlabform/processors/project/members_processor.py
+++ b/gitlabform/processors/project/members_processor.py
@@ -1,6 +1,6 @@
-import logging
-
-import cli_ui
+from logging import debug
+from cli_ui import debug as verbose
+from cli_ui import fatal
 
 from gitlabform import EXIT_INVALID_INPUT
 from gitlabform.gitlab import GitLab
@@ -15,7 +15,7 @@ class MembersProcessor(AbstractProcessor):
         groups = configuration.get("members|groups")
         if groups:
 
-            cli_ui.debug("Processing groups as members...")
+            verbose("Processing groups as members...")
 
             current_groups = self.gitlab.get_groups_from_project(project_and_group)
             for group in groups:
@@ -36,15 +36,13 @@ class MembersProcessor(AbstractProcessor):
                     and expires_at == current_groups[group]["expires_at"]
                     and access_level == current_groups[group]["group_access_level"]
                 ):
-                    logging.debug(
-                        "Ignoring group '%s' as it is already a member", group
-                    )
-                    logging.debug(
+                    debug("Ignoring group '%s' as it is already a member", group)
+                    debug(
                         "Current settings for '%s' are: %s"
                         % (group, current_groups[group])
                     )
                 else:
-                    logging.debug("Setting group '%s' as a member", group)
+                    debug("Setting group '%s' as a member", group)
                     access = access_level
                     expiry = expires_at
 
@@ -58,7 +56,7 @@ class MembersProcessor(AbstractProcessor):
         users = configuration.get("members|users")
         if users:
 
-            cli_ui.debug("Processing users as members...")
+            verbose("Processing users as members...")
 
             current_members = self.gitlab.get_members_from_project(project_and_group)
             for user in users:
@@ -78,13 +76,13 @@ class MembersProcessor(AbstractProcessor):
                     and expires_at == current_members[user]["expires_at"]
                     and access_level == current_members[user]["access_level"]
                 ):
-                    logging.debug("Ignoring user '%s' as it is already a member", user)
-                    logging.debug(
+                    debug("Ignoring user '%s' as it is already a member", user)
+                    debug(
                         "Current settings for '%s' are: %s"
                         % (user, current_members[user])
                     )
                 else:
-                    logging.debug("Setting user '%s' as a member", user)
+                    debug("Setting user '%s' as a member", user)
                     access = access_level
                     expiry = expires_at
                     self.gitlab.remove_member_from_project(project_and_group, user)
@@ -92,7 +90,7 @@ class MembersProcessor(AbstractProcessor):
                         project_and_group, user, access, expiry
                     )
         if not groups and not users:
-            cli_ui.fatal(
+            fatal(
                 "Project members configuration section has to contain"
                 " either 'users' or 'groups' non-empty keys.",
                 exit_code=EXIT_INVALID_INPUT,

--- a/gitlabform/processors/project/project_processor.py
+++ b/gitlabform/processors/project/project_processor.py
@@ -1,4 +1,4 @@
-import cli_ui
+from cli_ui import debug as verbose
 
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
@@ -13,8 +13,8 @@ class ProjectProcessor(AbstractProcessor):
         if project:
             if "archive" in project:
                 if project["archive"]:
-                    cli_ui.debug("Archiving project...")
+                    verbose("Archiving project...")
                     self.gitlab.archive(project_and_group)
                 else:
-                    cli_ui.debug("Unarchiving project...")
+                    verbose("Unarchiving project...")
                     self.gitlab.unarchive(project_and_group)

--- a/gitlabform/processors/project/project_push_rules_processor.py
+++ b/gitlabform/processors/project/project_push_rules_processor.py
@@ -1,6 +1,5 @@
-import logging
-
-import cli_ui
+from logging import debug
+from cli_ui import debug as verbose
 
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
@@ -14,14 +13,14 @@ class ProjectPushRulesProcessor(AbstractProcessor):
     def _process_configuration(self, project_and_group: str, configuration: dict):
         push_rules = configuration["project_push_rules"]
         old_project_push_rules = self.gitlab.get_project_push_rules(project_and_group)
-        logging.debug("Project push rules settings BEFORE: %s", old_project_push_rules)
+        debug("Project push rules settings BEFORE: %s", old_project_push_rules)
         if old_project_push_rules:
-            cli_ui.debug(f"Updating project push rules: {push_rules}")
+            verbose(f"Updating project push rules: {push_rules}")
             self.gitlab.put_project_push_rules(project_and_group, push_rules)
         else:
-            cli_ui.debug(f"Creating project push rules: {push_rules}")
+            verbose(f"Creating project push rules: {push_rules}")
             self.gitlab.post_project_push_rules(project_and_group, push_rules)
-        logging.debug(
+        debug(
             "Project push rules AFTER: %s",
             self.gitlab.get_project_push_rules(project_and_group),
         )

--- a/gitlabform/processors/project/project_settings_processor.py
+++ b/gitlabform/processors/project/project_settings_processor.py
@@ -1,6 +1,5 @@
-import logging
-
-import cli_ui
+from logging import debug
+from cli_ui import debug as verbose
 
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
@@ -13,13 +12,13 @@ class ProjectSettingsProcessor(AbstractProcessor):
 
     def _process_configuration(self, project_and_group: str, configuration: dict):
         project_settings = configuration["project_settings"]
-        logging.debug(
+        debug(
             "Project settings BEFORE: %s",
             self.gitlab.get_project_settings(project_and_group),
         )
-        cli_ui.debug(f"Setting project settings: {project_settings}")
+        verbose(f"Setting project settings: {project_settings}")
         self.gitlab.put_project_settings(project_and_group, project_settings)
-        logging.debug(
+        debug(
             "Project settings AFTER: %s",
             self.gitlab.get_project_settings(project_and_group),
         )

--- a/gitlabform/processors/project/schedules_processor.py
+++ b/gitlabform/processors/project/schedules_processor.py
@@ -1,4 +1,4 @@
-import logging
+from logging import debug
 from typing import Dict, List
 
 from gitlabform.gitlab import GitLab
@@ -19,21 +19,19 @@ class SchedulesProcessor(AbstractProcessor):
             schedule_ids = schedule_ids_by_description.get(schedule_description)
             if configuration.get("schedules|" + schedule_description + "|delete"):
                 if schedule_ids:
-                    logging.debug(
-                        "Deleting pipeline schedules '%s'", schedule_description
-                    )
+                    debug("Deleting pipeline schedules '%s'", schedule_description)
                     for schedule_id in schedule_ids:
                         self.gitlab.delete_pipeline_schedule(
                             project_and_group, schedule_id
                         )
                 else:
-                    logging.debug(
+                    debug(
                         "Not deleting pipeline schedules '%s', because none exist",
                         schedule_description,
                     )
             else:
                 if schedule_ids and len(schedule_ids) == 1:
-                    logging.debug(
+                    debug(
                         "Changing existing pipeline schedule '%s'", schedule_description
                     )
 
@@ -53,7 +51,7 @@ class SchedulesProcessor(AbstractProcessor):
                         ),
                     )
                 elif schedule_ids:
-                    logging.debug(
+                    debug(
                         "Replacing existing pipeline schedules '%s'",
                         schedule_description,
                     )
@@ -65,9 +63,7 @@ class SchedulesProcessor(AbstractProcessor):
                         configuration, project_and_group, schedule_description
                     )
                 else:
-                    logging.debug(
-                        "Creating pipeline schedule '%s'", schedule_description
-                    )
+                    debug("Creating pipeline schedule '%s'", schedule_description)
                     self.create_schedule_with_variables(
                         configuration, project_and_group, schedule_description
                     )
@@ -94,7 +90,7 @@ class SchedulesProcessor(AbstractProcessor):
 
         existing_variables = schedule.get("variables")
         if existing_variables:
-            logging.debug(
+            debug(
                 "Deleting variables for pipeline schedule '%s'", schedule["description"]
             )
 

--- a/gitlabform/processors/project/secret_variables_processor.py
+++ b/gitlabform/processors/project/secret_variables_processor.py
@@ -1,8 +1,9 @@
-import copy
-import logging
-import textwrap
+from logging import debug
+from cli_ui import debug as verbose
+from cli_ui import warning
 
-import cli_ui
+import copy
+import textwrap
 import yaml
 
 from gitlabform.gitlab import GitLab
@@ -20,12 +21,12 @@ class SecretVariablesProcessor(AbstractProcessor):
             self.gitlab.get_project_settings(project_and_group)["builds_access_level"]
             == "disabled"
         ):
-            cli_ui.warning(
+            warning(
                 "Builds disabled in this project so I can't set secret variables here."
             )
             return
 
-        logging.debug(
+        debug(
             "Secret variables BEFORE: %s",
             self.gitlab.get_secret_variables(project_and_group),
         )
@@ -35,18 +36,18 @@ class SecretVariablesProcessor(AbstractProcessor):
             if "delete" in configuration["secret_variables"][secret_variable]:
                 key = configuration["secret_variables"][secret_variable]["key"]
                 if configuration["secret_variables"][secret_variable]["delete"]:
-                    cli_ui.debug(
+                    verbose(
                         f"Deleting {secret_variable}: {key} in project {project_and_group}"
                     )
                     try:
                         self.gitlab.delete_secret_variable(project_and_group, key)
                     except:
-                        cli_ui.warning(
+                        warning(
                             f"Could not delete variable {key} in group {project_and_group}"
                         )
                     continue
 
-            cli_ui.debug(f"Setting secret variable: {secret_variable}")
+            verbose(f"Setting secret variable: {secret_variable}")
             try:
                 self.gitlab.put_secret_variable(
                     project_and_group,
@@ -58,7 +59,7 @@ class SecretVariablesProcessor(AbstractProcessor):
                     configuration["secret_variables"][secret_variable],
                 )
 
-        logging.debug(
+        debug(
             "Secret variables AFTER: %s",
             self.gitlab.get_secret_variables(project_and_group),
         )
@@ -73,20 +74,20 @@ class SecretVariablesProcessor(AbstractProcessor):
             for secret_variable in current_secret_variables:
                 secret_variable["value"] = hide(secret_variable["value"])
 
-            cli_ui.debug(f"Secret variables for {project_and_group} in GitLab:")
+            verbose(f"Secret variables for {project_and_group} in GitLab:")
 
-            cli_ui.debug(
+            verbose(
                 textwrap.indent(
                     yaml.dump(current_secret_variables, default_flow_style=False),
                     "  ",
                 )
             )
         except:
-            cli_ui.debug(
+            verbose(
                 f"Secret variables for {project_and_group} in GitLab cannot be checked."
             )
 
-        cli_ui.debug(f"Secret variables in {project_and_group} in configuration:")
+        verbose(f"Secret variables in {project_and_group} in configuration:")
 
         configured_secret_variables = copy.deepcopy(configuration)
         for key in configured_secret_variables.keys():
@@ -94,7 +95,7 @@ class SecretVariablesProcessor(AbstractProcessor):
                 configured_secret_variables[key]["value"]
             )
 
-        cli_ui.debug(
+        verbose(
             textwrap.indent(
                 yaml.dump(configured_secret_variables, default_flow_style=False),
                 "  ",

--- a/gitlabform/processors/project/services_processor.py
+++ b/gitlabform/processors/project/services_processor.py
@@ -1,4 +1,5 @@
-import cli_ui
+from cli_ui import debug as verbose
+from cli_ui import warning
 
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
@@ -11,7 +12,7 @@ class ServicesProcessor(AbstractProcessor):
     def _process_configuration(self, project_and_group: str, configuration: dict):
         for service in sorted(configuration["services"]):
             if configuration.get("services|" + service + "|delete"):
-                cli_ui.debug(f"Deleting service: {service}")
+                verbose(f"Deleting service: {service}")
                 self.gitlab.delete_service(project_and_group, service)
             else:
 
@@ -21,14 +22,14 @@ class ServicesProcessor(AbstractProcessor):
                 ):
                     # support from this configuration key has been added in v1.13.4
                     # we will remove it here to avoid passing it to the GitLab API
-                    cli_ui.warning(
+                    warning(
                         f"Ignoring deprecated 'recreate' field in the '{service}' service config. "
                         "Please remove it from the config file permanently as this workaround is not "
                         "needed anymore."
                     )
                     del configuration["services"][service]["recreate"]
 
-                cli_ui.debug(f"Setting service: {service}")
+                verbose(f"Setting service: {service}")
                 self.gitlab.set_service(
                     project_and_group, service, configuration["services"][service]
                 )

--- a/gitlabform/processors/project/tags_processor.py
+++ b/gitlabform/processors/project/tags_processor.py
@@ -1,6 +1,5 @@
-import logging
-
-import cli_ui
+from logging import debug
+from cli_ui import warning, fatal
 
 from gitlabform import EXIT_PROCESSING_ERROR
 from gitlabform.gitlab import GitLab
@@ -22,7 +21,7 @@ class TagsProcessor(AbstractProcessor):
                         if "create_access_level" in configuration["tags"][tag]
                         else None
                     )
-                    logging.debug("Setting tag '%s' as *protected*", tag)
+                    debug("Setting tag '%s' as *protected*", tag)
                     try:
                         # try to unprotect first
                         self.gitlab.unprotect_tag(project_and_group, tag)
@@ -30,14 +29,14 @@ class TagsProcessor(AbstractProcessor):
                         pass
                     self.gitlab.protect_tag(project_and_group, tag, create_access_level)
                 else:
-                    logging.debug("Setting tag '%s' as *unprotected*", tag)
+                    debug("Setting tag '%s' as *unprotected*", tag)
                     self.gitlab.unprotect_tag(project_and_group, tag)
             except NotFoundException:
                 message = f"Tag '{tag}' not found when trying to set it as protected/unprotected!"
                 if self.strict:
-                    cli_ui.fatal(
+                    fatal(
                         message,
                         exit_code=EXIT_PROCESSING_ERROR,
                     )
                 else:
-                    cli_ui.warning(message)
+                    warning(message)

--- a/gitlabform/processors/util/branch_protector.py
+++ b/gitlabform/processors/util/branch_protector.py
@@ -1,6 +1,5 @@
-import logging
-
-import cli_ui
+from logging import debug
+from cli_ui import warning, fatal
 
 from gitlabform import EXIT_PROCESSING_ERROR, EXIT_INVALID_INPUT
 from gitlabform.gitlab import GitLab
@@ -34,12 +33,12 @@ class BranchProtector(object):
         except NotFoundException:
             message = f"Branch '{branch}' not found when trying to set it as protected/unprotected!"
             if self.strict:
-                cli_ui.fatal(
+                fatal(
                     message,
                     exit_code=EXIT_PROCESSING_ERROR,
                 )
             else:
-                cli_ui.warning(message)
+                warning(message)
 
     def protect_branch(self, project_and_group, configuration, branch):
         try:
@@ -64,7 +63,7 @@ class BranchProtector(object):
                         requested_configuration, project_and_group, branch
                     )
                 else:
-                    logging.debug(
+                    debug(
                         "Skipping set branch '%s' access levels because they're already set"
                     )
 
@@ -77,16 +76,16 @@ class BranchProtector(object):
         except NotFoundException:
             message = f"Branch '{branch}' not found when trying to set it as protected/unprotected!"
             if self.strict:
-                cli_ui.fatal(
+                fatal(
                     message,
                     exit_code=EXIT_PROCESSING_ERROR,
                 )
             else:
-                cli_ui.warning(message)
+                warning(message)
 
     def unprotect_branch(self, project_and_group, branch):
         try:
-            logging.debug("Setting branch '%s' as unprotected", branch)
+            debug("Setting branch '%s' as unprotected", branch)
 
             # we don't know if the old or new API was used to protect
             # so use both when unprotecting
@@ -100,12 +99,12 @@ class BranchProtector(object):
         except NotFoundException:
             message = f"Branch '{branch}' not found when trying to set it as protected/unprotected!"
             if self.strict:
-                cli_ui.fatal(
+                fatal(
                     message,
                     exit_code=EXIT_PROCESSING_ERROR,
                 )
             else:
-                cli_ui.warning(message)
+                warning(message)
 
     def get_branch_protection_config_type(
         self, project_and_group, requested_configuration, branch
@@ -120,19 +119,19 @@ class BranchProtector(object):
             return "old"
 
         else:
-            cli_ui.fatal(
+            fatal(
                 f"Invalid configuration for protecting branches in project '{project_and_group}',"
                 f" branch '{branch}' - missing keys.",
                 exit_code=EXIT_INVALID_INPUT,
             )
 
     def protect_using_old_api(self, requested_configuration, project_and_group, branch):
-        cli_ui.warning(
+        warning(
             f"Using keys {self.old_api_keys} for configuring protected"
             " branches is deprecated and will be removed in future versions of GitLabForm."
             f" Please start using new keys: {self.new_api_keys}"
         )
-        logging.debug("Setting branch '%s' as *protected*", branch)
+        debug("Setting branch '%s' as *protected*", branch)
 
         # unprotect first to reset 'allowed to merge' and 'allowed to push' fields
         self.gitlab.unprotect_branch_new_api(project_and_group, branch)
@@ -145,7 +144,7 @@ class BranchProtector(object):
         )
 
     def protect_using_new_api(self, requested_configuration, project_and_group, branch):
-        logging.debug("Setting branch '%s' access level", branch)
+        debug("Setting branch '%s' access level", branch)
 
         # unprotect first to reset 'allowed to merge' and 'allowed to push' fields
         self.gitlab.unprotect_branch_new_api(project_and_group, branch)
@@ -161,7 +160,7 @@ class BranchProtector(object):
     def set_code_owner_approval_required(
         self, requested_configuration, project_and_group, branch
     ):
-        logging.debug(
+        debug(
             "Setting branch '%s' \"code owner approval required\" option",
             branch,
         )

--- a/gitlabform/processors/util/difference_logger.py
+++ b/gitlabform/processors/util/difference_logger.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 from itertools import starmap
 
-import cli_ui
+from cli_ui import debug as verbose
 
 
 # Simple function to create strings for values which should be hidden
@@ -68,4 +68,4 @@ class DifferenceLogger(object):
         if test:
             return text
         else:
-            cli_ui.debug(text)
+            verbose(text)

--- a/gitlabform/ui.py
+++ b/gitlabform/ui.py
@@ -19,6 +19,8 @@ from cli_ui import (
     Symbol,
     Token,
 )
+from cli_ui import debug as verbose
+
 from packaging import version as packaging_version
 from urllib.error import URLError
 
@@ -113,12 +115,12 @@ def show_header(
         groups, projects
     )
 
-    debug(f"groups: {groups_with_non_empty_configs}")
-    debug(
+    verbose(f"groups: {groups_with_non_empty_configs}")
+    verbose(
         f"(groups with empty effective configs that will be skipped: {groups_with_empty_configs})"
     )
-    debug(f"projects: {projects_with_non_empty_configs}")
-    debug(
+    verbose(f"projects: {projects_with_non_empty_configs}")
+    verbose(
         f"(projects with empty effective configs that will be skipped: {projects_with_empty_configs})"
     )
 


### PR DESCRIPTION
by importing cli_ui.debug as verbose while logging.debug
as debug, we avoid the confusion when will each type of
output be printed when using --verbose or --debug flags.

Also shorten the calls by using more selective imports.