### PR TITLE
Start accepting access levels names (only tests)

### DIFF
--- a/tests/acceptance/test_group_members.py
+++ b/tests/acceptance/test_group_members.py
@@ -204,3 +204,32 @@ class TestGroupMembers:
 
         with pytest.raises(SystemExit):
             run_gitlabform(zero_users, group)
+
+    def test__add_user_with_access_level_name(
+        self, gitlab, group, users, one_owner_and_two_developers
+    ):
+
+        no_of_members_before = len(gitlab.get_group_members(group))
+        user_to_add = f"{users[3]}"
+
+        add_users = f"""
+        projects_and_groups:
+          {group}/*:
+            group_members:
+              {users[0]}:
+                access_level: {AccessLevel.OWNER.value}
+              {users[1]}:
+                access_level: {AccessLevel.DEVELOPER.value}
+              {users[2]}:
+                access_level: {AccessLevel.DEVELOPER.value}
+              {user_to_add}: # new user 1
+                access_level: developer
+        """
+
+        run_gitlabform(add_users, group)
+
+        members = gitlab.get_group_members(group)
+        assert len(members) == no_of_members_before + 1
+
+        members_usernames = [member["username"] for member in members]
+        assert members_usernames.count(user_to_add) == 1

--- a/tests/acceptance/test_group_shared_with.py
+++ b/tests/acceptance/test_group_shared_with.py
@@ -193,3 +193,29 @@ class TestGroupSharedWith:
 
         shared_with = gitlab.get_group_shared_with(group)
         assert len(shared_with) == 0
+
+    def test__add_group_with_access_level_names(
+        self, gitlab, group, users, groups, one_owner
+    ):
+        no_of_members_before = len(gitlab.get_group_members(group))
+
+        add_shared_with = f"""
+            projects_and_groups:
+              {group}/*:
+                group_members:
+                  {users[0]}:
+                    access_level: {AccessLevel.OWNER.value}
+                group_shared_with:
+                  {groups[0]}:
+                    group_access_level: developer
+                  {groups[1]}:
+                    group_access_level: Developer # the case should not matter
+            """
+
+        run_gitlabform(add_shared_with, group)
+
+        members = gitlab.get_group_members(group)
+        assert len(members) == no_of_members_before, members
+
+        shared_with = gitlab.get_group_shared_with(group)
+        assert len(shared_with) == 2

--- a/tests/acceptance/test_members.py
+++ b/tests/acceptance/test_members.py
@@ -138,3 +138,31 @@ class TestMembers:
 
         with pytest.raises(SystemExit):
             run_gitlabform(config_with_error, group_and_project)
+
+    def test__add_user_with_access_level_names(
+        self, gitlab, group, project, users, one_maintainer_and_two_developers
+    ):
+        group_and_project = f"{group}/{project}"
+        members_before = gitlab.get_project_members(group_and_project)
+        no_of_members_before = len(members_before)
+        members_usernames_before = [member["username"] for member in members_before]
+
+        user_to_add = users[3]
+        assert user_to_add not in members_usernames_before
+
+        add_users = f"""
+            projects_and_groups:
+              {group}/{project}:
+                members:
+                  users:
+                    {user_to_add}: # new user
+                      access_level: developer
+            """
+
+        run_gitlabform(add_users, group_and_project)
+
+        members = gitlab.get_project_members(group_and_project)
+        assert len(members) == no_of_members_before + 1
+
+        members_usernames = [member["username"] for member in members]
+        assert user_to_add in members_usernames

--- a/tests/acceptance/test_tags.py
+++ b/tests/acceptance/test_tags.py
@@ -153,3 +153,34 @@ class TestTags:
             protected_tags[0]["create_access_levels"][0]["access_level"]
             == AccessLevel.NO_ACCESS.value
         )
+
+    def test__protect_single_tag_with_access_level_names(
+        self, gitlab, group, project, tags
+    ):
+        group_and_project = f"{group}/{project}"
+
+        config = f"""
+            projects_and_groups:
+              {group_and_project}:
+                tags:
+                  tag1:
+                    protected: true
+                    create_access_level: Maintainer
+            """
+
+        run_gitlabform(config, group_and_project)
+
+        tags = gitlab.get_tags(group_and_project)
+        for tag in tags:
+            if tag["name"] == "tag1":
+                assert tag["protected"]
+            else:
+                assert not tag["protected"]
+
+        protected_tags = gitlab.get_protected_tags(group_and_project)
+        assert len(protected_tags) == 1
+        assert protected_tags[0]["name"] == "tag1"
+        assert (
+            protected_tags[0]["create_access_levels"][0]["access_level"]
+            == AccessLevel.MAINTAINER.value
+        )


### PR DESCRIPTION
apart from their level numbers, as defined in https://docs.gitlab.com/ee/api/access_requests.html#valid-access-levels .