### PR TITLE
Run linter and tests workflow on every PR

### DIFF
--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -1,6 +1,10 @@
 name: Linter and tests
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   black-formatting:

--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -1,11 +1,6 @@
 name: Linter and tests
 
-on:
-  push:
-    branches:
-      - '**'
-  pull_request:
-    types: [opened]
+on: [pull_request]
 
 jobs:
   black-formatting:

--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -1,10 +1,10 @@
 name: Linter and tests
 
 on:
-  pull_request:
   push:
     branches:
-      - main
+      - '**'
+  pull_request:
 
 jobs:
   black-formatting:


### PR DESCRIPTION
@gdubicki This PR tries to solve https://github.com/egnyte/gitlabform/pull/273#issuecomment-919367567

When we use `on.event.branches` like this :

```yaml
on:
  push:
    branches:
      - '**'
  pull_request:
    types: [opened]
```

The workflow is only ran in a the base are evaluated. That means it'll only run workflow on branches in `egnyte/gitlabform` project. All unknown branch refs are ignored. The Workflow will also run when a PR is opened (just once) => will run for the `opened` event.