### PR TITLE
Fix GITLAB_EE_LICENSE: unbound variable

### DIFF
--- a/dev/run_gitlab_in_docker.sh
+++ b/dev/run_gitlab_in_docker.sh
@@ -49,7 +49,7 @@ if [[ -n $existing_gitlab_container_id ]] ; then
 fi
 
 gitlab_omnibus_config="gitlab_rails['initial_root_password'] = 'password'; registry['enable'] = false; grafana['enable'] = false; prometheus_monitoring['enable'] = false;"
-if [[ -f Gitlab.gitlab-license || -n "$GITLAB_EE_LICENSE" ]] ; then
+if [[ -f Gitlab.gitlab-license || -n "${GITLAB_EE_LICENSE:-}" ]] ; then
 
   mkdir -p $repo_root_directory/config
   rm -rf $repo_root_directory/config/*


### PR DESCRIPTION
When I followed the [contributing guide](https://github.com/egnyte/gitlabform/blob/main/CONTRIBUTING.md#running-acceptance-tests-using-gitlab-instance-in-docker) to start GitLab in a container, I got error: "GITLAB_EE_LICENSE: unbound variable".