### PR TITLE
chore: add json-schema for configuration syntax

### DIFF
--- a/.github/workflows/linter-and-tests.yml
+++ b/.github/workflows/linter-and-tests.yml
@@ -128,6 +128,26 @@ jobs:
           attempt_limit: 5
           attempt_delay: 10000
 
+  schemas-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code from the PR
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install test dependencies
+        run: |
+          pip install wheel
+          pip install -e .[test]
+      - name: Run schemas tests
+        run: |
+          pytest schemas/tests
+
   security-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-linter-and-tests.yml
+++ b/.github/workflows/pr-linter-and-tests.yml
@@ -166,6 +166,26 @@ jobs:
           attempt_limit: 5
           attempt_delay: 10000
 
+  schemas-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code from the PR
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install test dependencies
+        run: |
+          pip install wheel
+          pip install -e .[test]
+      - name: Run schemas tests
+        run: |
+          pytest schemas/tests
+
   security-tests:
     runs-on: ubuntu-latest
     steps:

--- a/docs/contrib/schema_development.md
+++ b/docs/contrib/schema_development.md
@@ -1,0 +1,49 @@
+# Schema Development
+
+Schemas for GitLabForm's configuration syntax is written using [JSON Schema](https://json-schema.org/).
+
+The `schemas/src/` directory contains various independent schemas and they are used to compose
+`schemas/src/gitlabform.json`. Each individual schemas typically correspond to variuos sections of
+GitLabForm's configuration. Having individual schemas makes it easy to unit test them with different
+sample data as well as easier to maintain.
+
+Currently the goal of these schemas is to help users compose their GitLabForm configuration. The schemas
+will be available via [schemastore catalog](https://www.schemastore.org/json/), which is supported by various
+editors. Using these schemas, the editors can provide helpful hint/tooltip, auto completion, details/example of
+configuration, etc.
+
+## Required tools
+
+- Python 3 and Pip 3 for development
+
+## Environment setup
+
+1. Create virtualenv with Python 3, for example in `venv` dir which is in `.gitignore` and activate it:
+
+```
+python3 -m venv venv
+. venv/bin/activate
+```
+
+## Developing schemas
+
+Curently the schemas are handwritten. They are not auto generated. Follow the existing schemas pattern when
+developing a new schema. Following resources maybe helpful:
+
+- [Understanding JSON Schema](https://json-schema.org/understanding-json-schema/): A good reference for JSON Schema.
+- [python-jsonschema](https://python-jsonschema.readthedocs.io/en/stable/): The library used in unit test for validating schemas.
+- [referencing](https://referencing.readthedocs.io/en/stable/): The library used in unit test that provides reference resolution between multiple schemas.
+
+### Running unit tests locally
+
+To run unit tests locally:
+
+1. Activate the virtualenv created above
+
+2. Install the dependencies for tests:
+
+    ```
+    pip install -e '.[test]'
+    ```
+
+3. Run `pytest schemas/tests` to run all the unit tests.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
   - 🙋 Contributing:
       - contrib/index.md
       - Local Development: contrib/local_development.md
+      - Schema Development: contrib/schema_development.md
       - Implementation Design: contrib/implementation_design.md
       - Coding Guidelines: contrib/coding_guidelines.md
       - Releases: contrib/releases.md

--- a/schemas/src/gitlabform.json
+++ b/schemas/src/gitlabform.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/gitlabform/gitlabform/main/schemas/gitlabform.json",
+  "title": "GitLabForm Configuration - v3 (draft)",
+  "description": "Draft Schema of GitLabForm v3 configuration syntax.",
+  "$comment": "The `additionalProperties` is allowed so that users can create yaml anchor and reference them as alias where needed. If it is not allowed, the schema will treat the yaml anchor as additional property and fail validation.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "config_version"
+  ],
+  "properties": {
+    "config_version": { "$ref": "/gitlabform/gitlabform/main/schemas/properties/config_version.json" },
+    "gitlab": { "$ref": "/gitlabform/gitlabform/main/schemas/properties/gitlab.json" },
+    "skip_projects": { "$ref": "/gitlabform/gitlabform/main/schemas/properties/skip_projects.json" },
+    "skip_groups": { "$ref": "/gitlabform/gitlabform/main/schemas/properties/skip_groups.json" }
+  }
+}

--- a/schemas/src/properties/config_version.json
+++ b/schemas/src/properties/config_version.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/gitlabform/gitlabform/main/schemas/properties/config_version.json",
+  "title": "GitLabForm configuration version.",
+  "description": "Required as of GitLabForm v3.x.x. This ensures that if the application behavior changes in a backward-incompatible way you won't apply unwanted configuration to your GitLab instance.",
+  "type": "integer",
+  "const": 3,
+  "default": 3
+}

--- a/schemas/src/properties/gitlab.json
+++ b/schemas/src/properties/gitlab.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/gitlabform/gitlabform/main/schemas/properties/gitlab.json",
+  "title": "GitLabForm configuration for accessing GitLab API.",
+  "description": "This allows GitLabForm to establish connection with given GitLab instance and perform updates accordingly.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "url": {
+      "type": "string",
+      "title": "GitLab instance URL.",
+      "description": "URL of GitLab instance where configurations will be applied. Alternatively use `GITLAB_URL` environment variable.",
+      "pattern": "^https?:\/\/.+$",
+      "examples": [
+        "https://gitlab.my-domain.com"
+      ]
+    },
+    "token": {
+      "type": "string",
+      "title": "GitLab Access Token with minimum `api` scope.",
+      "description": "Access token from GitLab for applying settings in gitlab. It's recommended to use `GITLAB_TOKEN` environment variable instead.",
+      "comment": "GitLab tokens are 20 characters long according to docs: https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html",
+      "minLength": 20,
+      "maxLength": 20
+    },
+    "ssl_verify": {
+      "type": "boolean",
+      "title": "Should SSL communication with GitLab be verified?",
+      "description": "Whether the SSL certificate of your GitLab instance should be verified. Set this to `false` if you are using a self-signed certificate (not recommended). No need to configure this unless changing default value.",
+      "default": true
+    },
+    "timeout": {
+      "type": "integer",
+      "title": "Timeout for communication with GitLab.",
+      "description": "Timeout for the whole requests to the GitLab API, in seconds. No need to configure this unless changing default value.",
+      "default": 10
+    }
+  }
+}

--- a/schemas/src/properties/skip_groups.json
+++ b/schemas/src/properties/skip_groups.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/gitlabform/gitlabform/main/schemas/properties/skip_groups.json",
+  "title": "GitLabForm configuration for skipping groups or namespaces.",
+  "description": "List of groups that will not be processed or updated by GitLabForm.",
+  "type": "array",
+  "minItems": 1,
+  "uniqueItems": true,
+  "items": {
+    "type": "string",
+    "title": "Group or namespace to be skipped.",
+    "description": "Enter complete path to the group or namespace from the root.",
+    "minLength": 1
+  },
+  "examples": [
+    "my-group",
+    "another-group/this-subgroup-only",
+    "another-group/every-subgroups-under-this-subgroup/*"
+  ]
+}

--- a/schemas/src/properties/skip_projects.json
+++ b/schemas/src/properties/skip_projects.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/gitlabform/gitlabform/main/schemas/properties/skip_projects.json",
+  "title": "GitLabForm configuration for skipping projects.",
+  "description": "List of projects that will not be processed or updated by GitLabForm.",
+  "type": "array",
+  "minItems": 1,
+  "uniqueItems": true,
+  "items": {
+    "type": "string",
+    "title": "Project to be skipped.",
+    "description": "Enter path to the project including full namespace.",
+    "comment": "Minimum length is set to 3 because all projects must be under a group or namespace. The shortest value can be 'a/b', where 'a' is the group or namespace and 'b' is the project path.",
+    "minLength": 3,
+    "pattern": "^.*\/.*$"
+  },
+  "examples": [
+    "my-group/project-foo",
+    "my-group/project-bar",
+    "another-group/every-projects-under-this-subgroup/*"
+  ]
+}

--- a/schemas/tests/conftest.py
+++ b/schemas/tests/conftest.py
@@ -1,0 +1,36 @@
+import pytest
+import json
+import jsonschema
+from pathlib import Path
+from jsonschema.protocols import Validator
+from referencing import Resource, Registry
+from typing import Callable, Generator
+
+
+@pytest.fixture(scope="session")
+def schema_registry() -> Generator[Registry, None, None]:
+    SCHEMA_DIR: Path = Path.cwd() / "schemas/src"
+    schema_registry: Registry = Registry()
+
+    schema_registry = [
+        Resource.from_contents(json.loads(schema_file.read_text()))
+        for schema_file in SCHEMA_DIR.glob("**/*.json")
+    ] @ schema_registry
+
+    schema_registry = schema_registry.crawl()
+
+    yield schema_registry
+
+
+@pytest.fixture(scope="function")
+def get_schema_validator(
+    schema_registry: Registry,
+) -> Generator[Callable[[str], Validator], None, None]:
+    def _get_schema_validator(schema_id: str) -> Validator:
+        schema = schema_registry.get_or_retrieve(schema_id).value.contents
+        validator_class = jsonschema.validators.validator_for(schema)
+        validator = validator_class(schema=schema, registry=schema_registry)
+
+        return validator
+
+    yield _get_schema_validator

--- a/schemas/tests/test-local.yaml
+++ b/schemas/tests/test-local.yaml
@@ -1,0 +1,2 @@
+foo: bar
+config_version: 4

--- a/schemas/tests/test_config_version.py
+++ b/schemas/tests/test_config_version.py
@@ -1,0 +1,85 @@
+import jsonschema
+import yaml
+import pytest
+import textwrap
+from jsonschema.exceptions import SchemaError, ValidationError
+
+
+class TestConfigVersion:
+    schema_id: str = "https://raw.githubusercontent.com/gitlabform/gitlabform/main/schemas/properties/config_version.json"
+    test_data: list[tuple[str, type[ValidationError] | None]] = [
+        (
+            f"""
+                1
+            """,
+            ValidationError,
+        ),
+        (
+            f"""
+                2
+            """,
+            ValidationError,
+        ),
+        (
+            f"""
+                3
+            """,
+            None,
+        ),
+        (
+            f"""
+                3.0
+            """,
+            None,
+        ),
+        (
+            f"""
+                3.5
+            """,
+            ValidationError,
+        ),
+        (
+            f"""
+                3.x
+            """,
+            ValidationError,
+        ),
+        (
+            f"""
+                config_version: 3
+            """,
+            ValidationError,
+        ),
+    ]
+
+    @pytest.mark.dependency()
+    def test__validate_config_version_schema(self, get_schema_validator):
+        validator = get_schema_validator(self.schema_id)
+
+        try:
+            validator.check_schema(validator.schema)
+        except SchemaError as error:
+            assert False, f"Schema is invalid: {error.message} - {error.json_path}"
+
+    @pytest.mark.dependency(
+        depends=["TestConfigVersion::test__validate_config_version_schema"]
+    )
+    @pytest.mark.parametrize("config_yaml, expected_error", test_data)
+    def test__config_of_config_version_schema(
+        self, get_schema_validator, config_yaml, expected_error
+    ):
+        validator = get_schema_validator(self.schema_id)
+        # f-strings with """ used as configs have the disadvantage of having indentation in them - let's remove it here
+        config = textwrap.dedent(config_yaml)
+
+        gitlabform_config = yaml.safe_load(config)
+
+        try:
+            validation_result = validator.validate(instance=gitlabform_config)
+            assert (
+                validation_result == expected_error
+            ), f"Config is invalid: {gitlabform_config}"
+        except ValidationError as error:
+            assert (
+                expected_error == ValidationError
+            ), f"Invalid config found as expected: {error.message}"

--- a/schemas/tests/test_gitlab.py
+++ b/schemas/tests/test_gitlab.py
@@ -1,0 +1,119 @@
+import yaml
+import pytest
+import textwrap
+from jsonschema.exceptions import SchemaError, ValidationError
+
+
+class TestGitlab:
+    schema_id: str = "https://raw.githubusercontent.com/gitlabform/gitlabform/main/schemas/properties/gitlab.json"
+    test_data: list[tuple[str, type[ValidationError] | None]] = [
+        (
+            f"""
+                url: http://localhost
+                token: glpat-1234567890-123
+                ssl_verify: true
+                timeout: 20
+            """,
+            None,
+        ),
+        (
+            f"""
+                url: https://localhost
+                token: glpat-1234567890-123
+                ssl_verify: true
+                timeout: 20
+            """,
+            None,
+        ),
+        # This one should fail because URL value doesn't match pattern
+        (
+            f"""
+                url: localhost
+                token: glpat-1234567890-123
+                ssl_verify: true
+                timeout: 20
+            """,
+            ValidationError,
+        ),
+        # This one should fail because token value is shorter than 20 characters
+        (
+            f"""
+                url: http://localhost
+                token: glpat-1234567890-12
+                ssl_verify: true
+                timeout: 20
+            """,
+            ValidationError,
+        ),
+        # This one should fail because token value is longer than 20 characters
+        (
+            f"""
+                url: http://localhost
+                token: glpat-1234567890-1234
+                ssl_verify: true
+                timeout: 20
+            """,
+            ValidationError,
+        ),
+        # This should fail because ssl_verify is not boolean
+        (
+            f"""
+                url: http://localhost
+                token: glpat-1234567890-123
+                ssl_verify: "true"
+                timeout: 20
+            """,
+            ValidationError,
+        ),
+        # This one should fail because timeout is not integer
+        (
+            f"""
+                url: http://localhost
+                token: glpat-1234567890-123
+                ssl_verify: true
+                timeout: "20"
+            """,
+            ValidationError,
+        ),
+        # This one should fail because additional properties are not allowed
+        (
+            f"""
+                url: http://localhost
+                token: glpat-1234567890-123
+                ssl_verify: true
+                timeout: 20
+                foo: bar
+            """,
+            ValidationError,
+        ),
+    ]
+
+    @pytest.mark.dependency()
+    def test__validate_gitlab_schema(self, get_schema_validator):
+        validator = get_schema_validator(self.schema_id)
+
+        try:
+            validator.check_schema(validator.schema)
+        except SchemaError as error:
+            assert False, f"Schema is invalid: {error.message} - {error.json_path}"
+
+    @pytest.mark.dependency(depends=["TestGitlab::test__validate_gitlab_schema"])
+    @pytest.mark.parametrize("config_yaml, expected_error", test_data)
+    def test__config_of_gitlabform_schema(
+        self, get_schema_validator, config_yaml, expected_error
+    ):
+        validator = get_schema_validator(self.schema_id)
+        # f-strings with """ used as configs have the disadvantage of having indentation in them - let's remove it here
+        config = textwrap.dedent(config_yaml)
+
+        gitlabform_config = yaml.safe_load(config)
+
+        try:
+            validation_result = validator.validate(instance=gitlabform_config)
+            assert (
+                validation_result == expected_error
+            ), f"Config is invalid: {gitlabform_config}"
+        except ValidationError as error:
+            assert (
+                expected_error == ValidationError
+            ), f"Invalid config found as expected: {error.message}"

--- a/schemas/tests/test_gitlabform-config.py
+++ b/schemas/tests/test_gitlabform-config.py
@@ -1,0 +1,87 @@
+import jsonschema
+import yaml
+import pytest
+import textwrap
+from jsonschema.exceptions import SchemaError, ValidationError
+
+
+class TestGitLabFormConfig:
+    schema_id: str = "https://raw.githubusercontent.com/gitlabform/gitlabform/main/schemas/gitlabform.json"
+    test_data: list[tuple[str, type[ValidationError] | None]] = [
+        (
+            f"""
+                config_version: 3
+                gitlab:
+                  url: http://localhost
+                skip_projects:
+                  - group-one/project-one
+                  - group-two/*
+                skip_groups:
+                  - group-three/subgroup-one
+                  - group-four/*
+            """,
+            None,
+        ),
+        (
+            f"""
+                config_version: 3
+                projects: &projects-to-skip
+                  - group-one/project-one
+                  - group-two/project-one
+                skip_projects: *projects-to-skip
+            """,
+            None,
+        ),
+        # This one should fail because config_version is require property but doesn't exist
+        (
+            f"""
+                gitlab:
+                  url: http://localhost
+            """,
+            ValidationError,
+        ),
+        # This one should fail because skip_groups is not an array
+        (
+            f"""
+                config_version: 3
+                projects: &projects-to-skip
+                  - group-one/project-one
+                  - group-two/project-one
+                skip_projects: *projects-to-skip
+                skip_groups: group-three
+            """,
+            ValidationError,
+        ),
+    ]
+
+    @pytest.mark.dependency()
+    def test__validate_gitlabform_schema(self, get_schema_validator):
+        validator = get_schema_validator(self.schema_id)
+
+        try:
+            validator.check_schema(validator.schema)
+        except SchemaError as error:
+            assert False, f"Schema is invalid: {error.message} - {error.json_path}"
+
+    @pytest.mark.dependency(
+        depends=["TestGitLabFormConfig::test__validate_gitlabform_schema"]
+    )
+    @pytest.mark.parametrize("config_yaml, expected_error", test_data)
+    def test__config_of_gitlabform_schema(
+        self, get_schema_validator, config_yaml, expected_error
+    ):
+        validator = get_schema_validator(self.schema_id)
+        # f-strings with """ used as configs have the disadvantage of having indentation in them - let's remove it here
+        config = textwrap.dedent(config_yaml)
+
+        gitlabform_config = yaml.safe_load(config)
+
+        try:
+            validation_result = validator.validate(instance=gitlabform_config)
+            assert (
+                validation_result == expected_error
+            ), f"Config is invalid: {gitlabform_config}"
+        except ValidationError as error:
+            assert (
+                expected_error == ValidationError
+            ), f"Invalid config found as expected: {error.message}"

--- a/schemas/tests/test_skip_groups.py
+++ b/schemas/tests/test_skip_groups.py
@@ -1,0 +1,119 @@
+import jsonschema
+import yaml
+import pytest
+import textwrap
+from jsonschema.exceptions import SchemaError, ValidationError
+
+
+class TestSkipGroups:
+    schema_id: str = "https://raw.githubusercontent.com/gitlabform/gitlabform/main/schemas/properties/skip_groups.json"
+    test_data: list[tuple[str, type[ValidationError] | None]] = [
+        (
+            f"""
+                - foo
+                - bar
+            """,
+            None,
+        ),
+        (
+            f"""
+                - group-one/subgroup/*
+                - group-two/subgroup/sub-subgroup
+            """,
+            None,
+        ),
+        # This one should fail because at least one item is required
+        (
+            f"""
+                []
+            """,
+            ValidationError,
+        ),
+        # This one should fail because duplicate entries are not allowed
+        (
+            f"""
+                - group-one/subgroup/*
+                - group-one/subgroup/*
+            """,
+            ValidationError,
+        ),
+        # This one should fail because empty value is not allowed
+        (
+            f"""
+                - ""
+            """,
+            ValidationError,
+        ),
+        # This one should fail because it's not an array
+        (
+            f"""
+                2
+            """,
+            ValidationError,
+        ),
+        # This one should fail because it's not an array
+        (
+            f"""
+                foo
+            """,
+            ValidationError,
+        ),
+        # This one should fail because it's not an array
+        (
+            f"""
+                foo: bar
+            """,
+            ValidationError,
+        ),
+        # This one should fail becaue it's not an array
+        (
+            f"""
+                groups:
+                  - group-one
+                  - group-two
+            """,
+            ValidationError,
+        ),
+        # This one should fail because one of the item in the array contains non-string value
+        (
+            f"""
+                - group-one/subgroup/*
+                - group-two/subgroup/sub-subgroup
+                - foo:
+                    key: value
+            """,
+            ValidationError,
+        ),
+    ]
+
+    @pytest.mark.dependency()
+    def test__validate_skip_group_schema(self, get_schema_validator):
+        validator = get_schema_validator(self.schema_id)
+
+        try:
+            validator.check_schema(validator.schema)
+        except SchemaError as error:
+            assert False, f"Schema is invalid: {error.message} - {error.json_path}"
+
+    @pytest.mark.dependency(
+        depends=["TestSkipGroups::test__validate_skip_group_schema"]
+    )
+    @pytest.mark.parametrize("config_yaml, expected_error", test_data)
+    def test__config_of_skip_groups_schema(
+        self, get_schema_validator, config_yaml, expected_error
+    ):
+        validator = get_schema_validator(self.schema_id)
+        # f-strings with """ used as configs have the disadvantage of having indentation in them - let's remove it here
+        config = textwrap.dedent(config_yaml)
+
+        gitlabform_config = yaml.safe_load(config)
+
+        try:
+            validation_result = validator.validate(instance=gitlabform_config)
+            assert (
+                validation_result == expected_error
+            ), f"Config is invalid: {gitlabform_config}"
+        except ValidationError as error:
+            assert (
+                expected_error == ValidationError
+            ), f"Invalid config found as expected: {error.message}"

--- a/schemas/tests/test_skip_projects.py
+++ b/schemas/tests/test_skip_projects.py
@@ -1,0 +1,127 @@
+import jsonschema
+import yaml
+import pytest
+import textwrap
+from jsonschema.exceptions import SchemaError, ValidationError
+
+
+class TestSkipProjects:
+    schema_id: str = "https://raw.githubusercontent.com/gitlabform/gitlabform/main/schemas/properties/skip_projects.json"
+    test_data: list[tuple[str, type[ValidationError] | None]] = [
+        (
+            f"""
+                - group-one/subgroup/*
+                - group-two/subgroup/project-hello-world
+            """,
+            None,
+        ),
+        (
+            f"""
+                - a/*
+                - b/c
+            """,
+            None,
+        ),
+        # This one should fail because at least one item is required
+        (
+            f"""
+                []
+            """,
+            ValidationError,
+        ),
+        # This one should fail because duplicate entries are not allowed
+        (
+            f"""
+                - group-one/subgroup/*
+                - group-one/subgroup/*
+            """,
+            ValidationError,
+        ),
+        # This one should fail because empty value is not allowed
+        (
+            f"""
+                - ""
+            """,
+            ValidationError,
+        ),
+        # This one should fail because project must be inside one namespace/group (i.e. `group-one/project-foo`)
+        (
+            f"""
+                - foo
+                - bar
+            """,
+            ValidationError,
+        ),
+        # This one should fail because it's not an array
+        (
+            f"""
+                2
+            """,
+            ValidationError,
+        ),
+        # This one should fail because it's not an array
+        (
+            f"""
+                foo
+            """,
+            ValidationError,
+        ),
+        # This one should fail because it's not an array
+        (
+            f"""
+                foo: bar
+            """,
+            ValidationError,
+        ),
+        # This one should fail becaue it's not an array
+        (
+            f"""
+                groups:
+                  - group-one/project-foo
+                  - group-two/project-bar
+            """,
+            ValidationError,
+        ),
+        # This one should fail because one of the item in the array contains non-string value
+        (
+            f"""
+                - group-one/subgroup/*
+                - group-two/subgroup/project-hello-world
+                - foo:
+                    key: value
+            """,
+            ValidationError,
+        ),
+    ]
+
+    @pytest.mark.dependency()
+    def test__validate_skip_projects_schema(self, get_schema_validator):
+        validator = get_schema_validator(self.schema_id)
+
+        try:
+            validator.check_schema(validator.schema)
+        except SchemaError as error:
+            assert False, f"Schema is invalid: {error.message} - {error.json_path}"
+
+    @pytest.mark.dependency(
+        depends=["TestSkipProjects::test__validate_skip_projects_schema"]
+    )
+    @pytest.mark.parametrize("config_yaml, expected_error", test_data)
+    def test__config_of_skip_groups_schema(
+        self, get_schema_validator, config_yaml, expected_error
+    ):
+        validator = get_schema_validator(self.schema_id)
+        # f-strings with """ used as configs have the disadvantage of having indentation in them - let's remove it here
+        config = textwrap.dedent(config_yaml)
+
+        gitlabform_config = yaml.safe_load(config)
+
+        try:
+            validation_result = validator.validate(instance=gitlabform_config)
+            assert (
+                validation_result == expected_error
+            ), f"Config is invalid: {gitlabform_config}"
+        except ValidationError as error:
+            assert (
+                expected_error == ValidationError
+            ), f"Invalid config found as expected: {error.message}"

--- a/setup.py
+++ b/setup.py
@@ -63,11 +63,13 @@ setup(
             "coverage==7.3.2",
             "cryptography==41.0.4",
             "deepdiff==6.6.0",
+            "jsonschema==4.18.6",
             "mypy==1.6.0",
             "mypy-extensions==1.0.0",
             "pre-commit==2.21.0",  # not really for tests, but for development
             "pytest==7.4.2",
             "pytest-cov==4.1.0",
+            "pytest-dependency==0.5.1",
             "pytest-rerunfailures==12.0",
             "xkcdpass==1.19.4",
         ],


### PR DESCRIPTION
This PR adds a [JSON Schema](https://json-schema.org/) for gitlabform configuration syntax as described in #499 . Few things to note about this schema:

The schema is manually created as opposed to generating from gitlabform build. I don't know if there's anything in-place to be able to auto-generate it. That may make it too complicated and hand-crafting the schema is probably good enough since gitlabform passes most of the configuration directly to gitlab api as parameter as opposed to writing special config syntax.

In this PR, only top-level syntax's schema has been added. For example:

```yaml
config_version: 3

gitlab:
  ssl_verify: true
  timeout: 10
  token: blah-23tlws623xwett
  url: gitlab.my-domain.com

skip_groups:
  - group1/subgroupA
  - group2/*

skip_projects:
  - group3/project1
```

Goal is to merge this PR with the above config's schema so that we have a starting point. That way others can also contribute or we can review changes in smaller chunks easily.
