### PR TITLE
docs: recommend uv instead of pipx for running/installing

### DIFF
--- a/docs/contrib/releases.md
+++ b/docs/contrib/releases.md
@@ -8,9 +8,9 @@ We try to follow the [PEP 440](https://peps.python.org/pep-0440/) versioning sch
 
 1. Make sure you're on `main` branch and it is up-to-date.
 2. Add an entry in [changelog.md](../changelog.md). Remember to give thanks to all the contributors! Commit this change.
-3. Update version using [`tbump`](https://github.com/your-tools/tbump). Run `pipx run tbump <new-semantic-version-number>`.
+3. Update version using [`tbump`](https://github.com/your-tools/tbump). Run `uvx tbump <new-semantic-version-number>`.
 
-    **Note**: You may need to install `pipx` first if it's not already installed. Follow the instructions at [`pipx` documentation](https://pypa.github.io/pipx/installation/).
+    **Note**: You may need to install `uv` first if it's not already installed. Follow the instructions at [`uv` documentation](https://docs.astral.sh/uv/getting-started/).
 
     Executing `tbump` will create a commit containing version updates to necessary files (i.e. `tbump.toml`, `pyproject.toml`), create a new tag from for the new version from the current `ref` in `main` branch, and finally push the commits and tag to remote.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,9 +10,9 @@ You can just run the latest stable version with:
 ```shell
 docker run -it -v $(pwd):/config ghcr.io/gitlabform/gitlabform:latest gitlabform
 ```
-* [pipx](https://github.com/pypa/pipx):
-```shell
-pipx run gitlabform
+* [uv](https://github.com/astral-sh/uv):
+```uv
+uvx gitlabform
 ```
 
 
@@ -22,9 +22,9 @@ Similarly, you can run the latest 3.* version with:
 ```shell
 docker run -it -v $(pwd):/config ghcr.io/gitlabform/gitlabform:3 gitlabform
 ```
-* [pipx](https://github.com/pypa/pipx):
+* [uv](https://github.com/astral-sh/uv):
 ```shell
-pipx run --spec 'gitlabform>=3,<4' gitlabform
+uvx --from 'gitlabform>=3,<4' gitlabform
 ```
 
 See [this](https://github.com/gitlabform/gitlabform/pkgs/container/gitlabform) for all the available Docker tags.
@@ -34,9 +34,9 @@ See [this](https://github.com/gitlabform/gitlabform/pkgs/container/gitlabform) f
 
 If you **do** want to install the app you can do it with:
 
-* [pipx](https://github.com/pypa/pipx) (recommended):
+* [uv](https://github.com/astral-sh/uv) (recommended):
 ```shell
-pipx install gitlabform
+uv tool install gitlabform
 ``` 
 * plain `pip`:
 ```shell


### PR DESCRIPTION
as it handles Python upgrades automatically, while pipx may keep you stuck with the existing, old version of Python (unless I am missing something)

It's also the ✨shiny new thing✨