### PR TITLE
test: fix group push rule test assertion

### DIFF
--- a/tests/acceptance/premium/test_group_push_rules.py
+++ b/tests/acceptance/premium/test_group_push_rules.py
@@ -40,5 +40,5 @@ class TestGroupPushRules:
         push_rules = group.pushrules.get()
         assert push_rules.commit_message_regex == ""
         assert push_rules.member_check is True
-        assert push_rules.commit_committer_check is None
+        assert push_rules.commit_committer_check is False
         assert push_rules.commit_committer_name_check is False


### PR DESCRIPTION
One of the test for group push rule was set to validate the 'commit_committer_check' attribute. Currently it is set to 'None' if the attribute is not set. But in recent GitLab release, the API is returning boolean value. So, the test is failing causing the CI to be broken

This change updates test assertion to match with what GitLab's API returns. This will restore the CI pipeline to working state.