### PR TITLE
feat: add deprecation warning for saml_group_links

### DIFF
--- a/gitlabform/processors/group/group_saml_links_processor.py
+++ b/gitlabform/processors/group/group_saml_links_processor.py
@@ -1,5 +1,6 @@
-from logging import debug
+from logging import debug, warning
 from typing import List
+from cli_ui import info
 
 from gitlabform.gitlab import GitLab
 from gitlab.v4.objects import Group, GroupSAMLGroupLink
@@ -13,6 +14,10 @@ class GroupSAMLLinksProcessor(AbstractProcessor):
 
     def _process_configuration(self, group_path: str, configuration: dict) -> None:
         """Process the SAML links configuration for a group."""
+        if "saml_group_links" in configuration:
+            info(
+                "CONFIG DEPRECATION: The 'saml_group_links' key is deprecated and will be changed to `group_saml_links` in a future version."
+            )
 
         configured_links = configuration.get("saml_group_links", {})
         enforce_links = configuration.get("saml_group_links|enforce", False)


### PR DESCRIPTION
Adds a warning message to inform users that the `saml_group_links` configuration key is deprecated and will be renamed to `group_saml_links` in a future release.

This change is being made to improve consistency across group-level configuration syntax.

related-to #1078