### PR TITLE
docs: fix broken ordered list formatting

### DIFF
--- a/docs/contrib/local_development.md
+++ b/docs/contrib/local_development.md
@@ -62,15 +62,23 @@ against a disposable GitLab instance running as a Docker container OR use your o
 
 1. Run below command to start GitLab in a docker container. Note that it may take a few minutes!
 
-```
-./dev/run_gitlab_in_docker.sh
-```
+    ```
+    ./dev/run_gitlab_in_docker.sh
+    ```
 
 2. Run `pytest tests/acceptance` to start all tests.
-To run only a single class with tests run, f.e.:
-- `pytest tests/acceptance -k "TestArchiveProject"`.
-To run a single test method run, f.e.:
-- `pytest tests/acceptance -k "test__set_file_strongly_protected_branch"`.
+
+    To run only a single class with tests run, f.e.:
+
+    ```
+    pytest tests/acceptance -k "TestArchiveProject"
+    ```
+
+    To run a single test method run, f.e.:
+
+    ```
+    pytest tests/acceptance -k "test__set_file_strongly_protected_branch"
+    ```
 
 ### Acceptance tests for GitLab paid features
 


### PR DESCRIPTION
This fixes:

<img width="757" height="320" alt="before" src="https://github.com/user-attachments/assets/95bdd16e-7ce0-4e99-8d07-ebc14b2cf93d" />

to:

<img width="757" height="447" alt="after" src="https://github.com/user-attachments/assets/e5e1e08b-e508-41ce-a4e1-2aadcc25df56" />
