### PR TITLE
style: Apply black v26 formatting

### DIFF
--- a/gitlabform/__init__.py
+++ b/gitlabform/__init__.py
@@ -143,8 +143,7 @@ class GitLabForm:
         :return: a tuple with all the arguments that have been parsed
         """
         parser = argparse.ArgumentParser(
-            description=textwrap.dedent(
-                f"""
+            description=textwrap.dedent(f"""
             🏗 Specialized configuration as a code tool for GitLab projects, groups and more
             using hierarchical configuration written in YAML.
 
@@ -152,8 +151,7 @@ class GitLabForm:
               * 0 - on success,
               * {EXIT_INVALID_INPUT} - on invalid input errors (f.e. bad syntax in the config file) ~ "it's your fault". 😅
               * {EXIT_PROCESSING_ERROR} - if there were backend processing errors (f.e. when requests to GitLab fail) ~ "it's not your fault". 😎
-            """
-            ),
+            """),
             formatter_class=Formatter,
         )
 

--- a/gitlabform/configuration/__init__.py
+++ b/gitlabform/configuration/__init__.py
@@ -2,7 +2,6 @@ from gitlabform.configuration.common import ConfigurationCommon
 from gitlabform.configuration.groups import ConfigurationGroups
 from gitlabform.configuration.projects import ConfigurationProjects
 
-
 #
 # This the only external interface for operating on the configuration from a given YAML file
 # (or an input string in case of tests).

--- a/gitlabform/configuration/core.py
+++ b/gitlabform/configuration/core.py
@@ -101,11 +101,11 @@ class ConfigurationCore(ABC):
         if config_string:
             config = textwrap.dedent(source)
             verbose("Reading config from the provided string.")
-            (yaml_data, doc_loaded) = Parsers.get_yaml_data(yaml, log, config, literal=True)
+            yaml_data, doc_loaded = Parsers.get_yaml_data(yaml, log, config, literal=True)
         else:
             config_path = source
             verbose(f"Reading config from file: {config_path}")
-            (yaml_data, doc_loaded) = Parsers.get_yaml_data(yaml, log, config_path)
+            yaml_data, doc_loaded = Parsers.get_yaml_data(yaml, log, config_path)
 
         if doc_loaded:
             debug("Config parsed successfully as YAML.")

--- a/gitlabform/configuration/transform.py
+++ b/gitlabform/configuration/transform.py
@@ -15,7 +15,6 @@ from gitlabform.configuration import Configuration
 from gitlabform.gitlab import AccessLevel
 from gitlabform.gitlab import GitLab
 
-
 # Configuration transformers are classes which take the input configuration as YAML and change it
 # to from the more user-friendly input to an output that is more applicable to passing to GitLab
 # over its API.

--- a/gitlabform/lists/filter.py
+++ b/gitlabform/lists/filter.py
@@ -5,7 +5,6 @@ from cli_ui import fatal
 from gitlabform.constants import EXIT_INVALID_INPUT
 from gitlabform.lists import OmissionReason, Groups, Projects
 
-
 # Groups and projects filters jobs is to omit some groups and projects that GitLabForm is requested
 # to process for a speed-up.
 #

--- a/gitlabform/processors/abstract_processor.py
+++ b/gitlabform/processors/abstract_processor.py
@@ -43,10 +43,8 @@ class AbstractProcessor(ABC):
                 project_transfer_source = ""
                 try:
                     project_transfer_source = configuration["project"]["transfer_from"]
-                    verbose(
-                        f"""Project {project_or_project_and_group} is configured to be transferred, 
-                        diffing config from transfer source project {project_transfer_source}."""
-                    )
+                    verbose(f"""Project {project_or_project_and_group} is configured to be transferred, 
+                        diffing config from transfer source project {project_transfer_source}.""")
                 except KeyError:
                     pass
 

--- a/tests/unit/configuration/transform/test_merge_request_approvals_transformer.py
+++ b/tests/unit/configuration/transform/test_merge_request_approvals_transformer.py
@@ -16,7 +16,6 @@ from gitlabform.configuration.transform import (
 )
 from gitlabform.gitlab import GitLab
 
-
 #
 # TODO: remove below test(s) in v4.x
 #

--- a/tests/unit/processors/test_difference_logger.py
+++ b/tests/unit/processors/test_difference_logger.py
@@ -12,13 +12,11 @@ def test_empty_dict_current():
     }
     result = DifferenceLogger.log_diff("test", current_config, config_to_apply, False, None, True)
     # the whitespace after "123" below is required!
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
         test:
         foo: "???" => 123       
         bar: "???" => "whatever"
-    """
-    ).strip()
+    """).strip()
     assert result == expected
 
 
@@ -30,13 +28,11 @@ def test_none_current():
     }
     result = DifferenceLogger.log_diff("test", current_config, config_to_apply, False, None, True)
     # the whitespace after "123" below is required!
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
         test:
         foo: "???" => 123       
         bar: "???" => "whatever"
-    """
-    ).strip()
+    """).strip()
     assert result == expected
 
 
@@ -51,12 +47,10 @@ def test_diff_from_current():
     }
     result = DifferenceLogger.log_diff("test", current_config, config_to_apply, True, None, True)
     # the whitespace after "123" below is required!
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
         test:
         foo: 456 => 123       
-    """
-    ).strip()
+    """).strip()
     assert result == expected
 
 
@@ -71,9 +65,7 @@ def test_diff_output_no_changes():
     }
     result = DifferenceLogger.log_diff("test", current_config, config_to_apply, True, None, True)
 
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
 
-    """
-    ).strip()
+    """).strip()
     assert result == expected


### PR DESCRIPTION
The CI environment uses black v26, which reported formatting errors against the codebase. This is why currently PRs are not mergeable.

This commit applies the updated formatting rules to align with the CI and resolve the linting failures.