### PR TITLE
fix: handle nested inherit breaks

### DIFF
--- a/gitlabform/configuration/core.py
+++ b/gitlabform/configuration/core.py
@@ -180,6 +180,14 @@ class ConfigurationCore(ABC):
         merged_dict = merge({}, more_general_config, more_specific_config)
 
         def break_inheritance(specific_config, parent_path=()):
+            """
+            Walk the specific config tree and replace only the exact nested section
+            that declares ``inherit: false``.
+
+            ``parent_path`` stores the full key path to the current section because
+            the same section name, like ``variables``, can appear in multiple branches.
+            Replacing by section name alone can therefore update the wrong subtree.
+            """
             for key, value in specific_config.items():
                 if "inherit" == key:
                     if not value:
@@ -194,6 +202,10 @@ class ConfigurationCore(ABC):
                     break_inheritance(value, parent_path + (key,))
 
         def replace_config_section(merged_config, parent_path, specific_config):
+            """
+            Replace the merged section at ``parent_path`` with the specific section
+            that requested an inheritance break, dropping the control flag itself.
+            """
             target_config = merged_config
             for key in parent_path[:-1]:
                 target_config = target_config[key]

--- a/gitlabform/configuration/core.py
+++ b/gitlabform/configuration/core.py
@@ -179,11 +179,11 @@ class ConfigurationCore(ABC):
 
         merged_dict = merge({}, more_general_config, more_specific_config)
 
-        def break_inheritance(specific_config, parent_key=""):
+        def break_inheritance(specific_config, parent_path=()):
             for key, value in specific_config.items():
                 if "inherit" == key:
                     if not value:
-                        replace_config_sections(merged_dict, parent_key, specific_config)
+                        replace_config_section(merged_dict, parent_path, specific_config)
                         break
                     elif value:
                         fatal(
@@ -191,16 +191,16 @@ class ConfigurationCore(ABC):
                             exit_code=EXIT_INVALID_INPUT,
                         )
                 elif type(value) in [CommentedMap, dict]:
-                    break_inheritance(value, key)
+                    break_inheritance(value, parent_path + (key,))
 
-        def replace_config_sections(merged_config, specific_key, specific_config):
-            for key, value in merged_config.items():
-                if specific_key == key:
-                    del specific_config["inherit"]
-                    merged_config[key] = specific_config
-                    break
-                elif type(value) in [CommentedMap, dict]:
-                    replace_config_sections(value, specific_key, specific_config)
+        def replace_config_section(merged_config, parent_path, specific_config):
+            target_config = merged_config
+            for key in parent_path[:-1]:
+                target_config = target_config[key]
+
+            replacement_config = deepcopy(specific_config)
+            replacement_config.pop("inherit", None)
+            target_config[parent_path[-1]] = replacement_config
 
         break_inheritance(more_specific_config)
 

--- a/tests/unit/configuration/test_inheritance_break_projects_and_groups.py
+++ b/tests/unit/configuration/test_inheritance_break_projects_and_groups.py
@@ -187,3 +187,51 @@ class TestInheritanceBreakProjectsAndGroups:
         assert variables == {
             "secret3": {"key": "bizz", "value": "buzz"},
         }
+
+    def test__inheritance_break__flag_set_at_nested_level__replaces_only_matching_path(
+        self,
+    ):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          "*":
+            project_settings:
+              section_a:
+                variables:
+                  secret1:
+                    key: foo
+                    value: bar
+              section_b:
+                variables:
+                  secret2:
+                    key: fizz
+                    value: buzz
+
+          "some_group/my_project":
+            project_settings:
+              section_b:
+                variables:
+                  inherit: false
+                  secret3:
+                    key: bizz
+                    value: fuzz
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_config = configuration.get_effective_config_for_project("some_group/my_project")
+
+        assert effective_config == {
+            "project_settings": {
+                "section_a": {
+                    "variables": {
+                        "secret1": {"key": "foo", "value": "bar"},
+                    }
+                },
+                "section_b": {
+                    "variables": {
+                        "secret3": {"key": "bizz", "value": "fuzz"},
+                    }
+                },
+            }
+        }


### PR DESCRIPTION
* resolves #1233 
* Updated `core.py` so `inherit: false` replaces only the exact nested config section by full path, preventing incorrect section replacement and the resulting `KeyError` during config merging.