### PR TITLE
fix(acceptance): use safe_load in test running

### DIFF
--- a/tests/acceptance/standard/test_running.py
+++ b/tests/acceptance/standard/test_running.py
@@ -42,7 +42,7 @@ class TestRunning:
 
         path = Path("output.yml")
         yaml = YAML(typ="safe")
-        assert yaml.load(path)
+        assert yaml.safe_load(path)
 
     # noinspection PyPep8Naming
     def test__ALL_dry_run(self, gl, project, other_project):


### PR DESCRIPTION
`yaml.load()` in `tests/acceptance/standard/test_running.py` doesn't pass a safe Loader. This can deserialize arbitrary Python objects and is an RCE risk if the YAML comes from user input or the network. Switched to `yaml.safe_load()`.