### PR TITLE
test: restore Premium & Ultimate test functionality in CI

### DIFF
--- a/.github/workflows/tests-standard.yml
+++ b/.github/workflows/tests-standard.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Start GitLab in Docker
         run: ./dev/run_gitlab_in_docker.sh
       - name: Run standard acceptance tests against Enterprise Edition
-        run: pytest --cov=. --cov-report=xml --durations=0 --reruns 3 --reruns-delay 10 tests/acceptance/standard
+        run: pytest --cov=. --cov-report=xml --durations=0 --reruns 3 --reruns-delay 10 --log-cli-level=WARNING tests/acceptance/standard
       - name: Upload coverage to Codecov
         uses: Wandalen/wretry.action@v3
         with:
@@ -70,7 +70,7 @@ jobs:
       - name: Start GitLab in Docker
         run: ./dev/run_gitlab_in_docker.sh --gitlab-flavor ce
       - name: Run standard acceptance tests against Community Edition
-        run: pytest --cov=. --cov-report=xml --durations=0 --reruns 3 --reruns-delay 10 tests/acceptance/standard
+        run: pytest --cov=. --cov-report=xml --durations=0 --reruns 3 --reruns-delay 10 --log-cli-level=WARNING tests/acceptance/standard
       - name: Upload coverage to Codecov
         uses: Wandalen/wretry.action@v3
         with:

--- a/docs/contrib/local_development.md
+++ b/docs/contrib/local_development.md
@@ -72,7 +72,7 @@ against a disposable GitLab instance running as a Docker container OR use your o
     ./dev/run_gitlab_in_docker.sh --gitlab-flavor ce
     ```
 
-2. Run `pytest tests/acceptance` to start all tests.
+2. Run `pytest tests/acceptance --log-cli-level=INFO` to start all tests.
 
     To run only a single class with tests run, f.e.:
 

--- a/docs/contrib/workflows.md
+++ b/docs/contrib/workflows.md
@@ -1,0 +1,16 @@
+# GitHub Workflows
+
+We trigger acceptance tests on GitHub Actions against "Self-hosted" images of GitLab with temporary licenses granted to 
+us by GitLab's customer success team.
+
+These tests are run in an GitHub Environment, requiring approval from a maintainer, and the licenses assigned to this
+project's maintainers are stored as GitHub Repository Secrets to prevent misuse.
+
+We use `pull_request_target` as the event to trigger PR pipelines - which has a downside that we can't test our 
+pipelines until merged into main, but allows us to pass License Secrets to Forks more easily.
+
+## License management
+
+Requesting new Premium/Ultimate Licenses is done via GitLab's Contribution to EE process [here](https://handbook.gitlab.com/handbook/marketing/developer-relations/contributor-success/community-contributors-workflows/#contributing-to-the-gitlab-enterprise-edition-ee).
+
+As a Maintainer, when you receive a new license key, please add/update it to the GitHub Repository Secrets.

--- a/gitlabform/__init__.py
+++ b/gitlabform/__init__.py
@@ -321,15 +321,14 @@ class GitLabForm:
 
         :param tests: True if we are running in tests mode
         """
+        rich_tracebacks = False
         if tests or self.debug:
             level = logging.DEBUG
             rich_tracebacks = True
         elif self.verbose:
             level = logging.INFO
-            rich_tracebacks = False
         else:
             level = logging.WARNING
-            rich_tracebacks = False
 
         logging.basicConfig(
             level=level, format="%(message)s", datefmt="[%X]", handlers=[RichHandler(rich_tracebacks=rich_tracebacks)]

--- a/gitlabform/gitlab/__init__.py
+++ b/gitlabform/gitlab/__init__.py
@@ -1,5 +1,6 @@
 import enum
 import inspect
+import logging
 
 from typing import List
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,8 @@ exclude = ["tests*"]
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning"]
 markers = [
-    "requires_license: marks tests which require GitLab paid (Premium/Ultimate) license '-m \"not requires_license\"')",
+    "requires_license: marks tests which require GitLab paid (Premium) license",
+    "requires_ultimate_license: marks tests which require GitLab paid (Ultimate) license)",
     "ce: marks tests which need to be run against GitLab CE image as well as the standard EE image"
 ]
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -43,7 +43,7 @@ def requires_license(gl: Gitlab, request):
 
     gitlab_license = gl.get_license()
     if not gitlab_license:
-        pytest.skip("this test requires a GitLab license (Paid/Trial)")
+        pytest.fail("This test requires a GitLab license")
     if gitlab_license["expired"]:
         pytest.fail("GitLab license has expired, please request a new one")
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -42,10 +42,31 @@ def requires_license(gl: Gitlab, request):
         return
 
     gitlab_license = gl.get_license()
+    requires_active_license(gitlab_license, "premium")
+
+
+@pytest.fixture(autouse=True)
+def requires_ultimate_license(gl: Gitlab, request):
+    if not request.node.get_closest_marker("requires_ultimate_license"):
+        return
+
+    gitlab_license = gl.get_license()
+    requires_active_license(gitlab_license, "ultimate")
+
+    plan = gitlab_license["plan"]
+    if plan is not "ultimate":
+        pytest.fail("Test requires GitLab Ultimate license")
+
+
+def requires_active_license(gitlab_license: dict[str, str | dict[str, str]], license_type: str):
     if not gitlab_license:
-        pytest.fail("This test requires a GitLab license")
-    if gitlab_license["expired"]:
-        pytest.fail("GitLab license has expired, please request a new one")
+        pytest.fail(f"This test requires a GitLab {license_type} license")
+
+    expires_at = date.fromisoformat(gitlab_license["expires_at"])
+    now = date.today()
+
+    if expires_at <= now:
+        pytest.fail(f"GitLab {license_type} license has expired, please request a new one")
 
 
 @pytest.fixture(scope="session")

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -53,7 +53,7 @@ def requires_ultimate_license(gl: Gitlab, request):
     gitlab_license = gl.get_license()
     requires_active_license(gitlab_license, "ultimate")
 
-    if gitlab_license.get("plan", "").lower() != "ultimate":
+    if gitlab_license.get("plan", "") != "ultimate":
         pytest.fail("Test requires GitLab Ultimate license")
 
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -53,8 +53,7 @@ def requires_ultimate_license(gl: Gitlab, request):
     gitlab_license = gl.get_license()
     requires_active_license(gitlab_license, "ultimate")
 
-    plan = gitlab_license["plan"]
-    if plan is not "ultimate":
+    if gitlab_license.get("plan", "").lower() != "ultimate":
         pytest.fail("Test requires GitLab Ultimate license")
 
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -42,8 +42,10 @@ def requires_license(gl: Gitlab, request):
         return
 
     gitlab_license = gl.get_license()
-    if not gitlab_license or gitlab_license["expired"]:
+    if not gitlab_license:
         pytest.skip("this test requires a GitLab license (Paid/Trial)")
+    if gitlab_license["expired"]:
+        pytest.fail("GitLab license has expired, please request a new one")
 
 
 @pytest.fixture(scope="session")

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -58,15 +58,14 @@ def requires_ultimate_license(gl: Gitlab, request):
         pytest.fail("Test requires GitLab Ultimate license")
 
 
-def requires_active_license(gitlab_license: dict[str, str | dict[str, str]], license_type: str):
+def requires_active_license(gitlab_license, license_type: str):
     if not gitlab_license:
         pytest.fail(f"This test requires a GitLab {license_type} license")
 
-    expires_at = date.fromisoformat(gitlab_license["expires_at"])
-    now = date.today()
-
-    if expires_at <= now:
-        pytest.fail(f"GitLab {license_type} license has expired, please request a new one")
+    expires_at_string = gitlab_license.get("expires_at")
+    if expires_at_string is not None:
+        if date.fromisoformat(expires_at_string) <= date.today():
+            pytest.fail(f"GitLab {license_type} license has expired, please request a new one")
 
 
 @pytest.fixture(scope="session")

--- a/tests/acceptance/premium/test_group_variables.py
+++ b/tests/acceptance/premium/test_group_variables.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import patch
 import pytest
 from logging import info
@@ -121,7 +122,7 @@ class TestGroupVariablesPremium:
         assert variables[1].value == "prod-new-value"
         assert variables[1].environment_scope == "prod"
 
-    def test__delete_variables_with_env_scope(self, group, capsys):
+    def test__delete_variables_with_env_scope(self, group, caplog):
         """Test case: Variable deletion scenarios"""
 
         # Clear any existing variables from previous tests since 'group' is class-scoped
@@ -173,10 +174,10 @@ class TestGroupVariablesPremium:
                 environment_scope: dev  # wrong scope, actual is 'prod'
                 delete: true
         """
-        with pytest.raises(SystemExit) as exc_info:
-            run_gitlabform(config_wrong_scope, group)
-        captured = capsys.readouterr()
-        assert "Cannot delete variable 'WRONG_SCOPE' with scope 'dev' - variable does not exist" in captured.err
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(SystemExit) as exc_info:
+                run_gitlabform(config_wrong_scope, group)
+        assert "Cannot delete variable 'WRONG_SCOPE' with scope 'dev' - variable does not exist" in caplog.text
 
         # Test 3: Delete should fail when specified attributes don't match
         config_mismatch = f"""
@@ -190,10 +191,10 @@ class TestGroupVariablesPremium:
                 environment_scope: prod # match
                 delete: true
         """
-        with pytest.raises(SystemExit) as exc_info:
-            run_gitlabform(config_mismatch, group)
-        captured = capsys.readouterr()
-        assert "Cannot delete MULTI_ATTR - attributes don't match" in captured.err
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(SystemExit) as exc_info:
+                run_gitlabform(config_mismatch, group)
+        assert "Cannot delete MULTI_ATTR - attributes don't match" in caplog.text
 
         # Test 4: Delete should succeed when providing subset of attributes
         config_partial = f"""

--- a/tests/acceptance/ultimate/test_group_members.py
+++ b/tests/acceptance/ultimate/test_group_members.py
@@ -4,6 +4,8 @@ from gitlabform import EXIT_PROCESSING_ERROR
 from gitlabform.gitlab import AccessLevel
 from tests.acceptance import run_gitlabform
 
+pytestmark = pytest.mark.requires_ultimate_license
+
 
 class TestGroupMembers:
     def test__add_user_to_group_members_with_custom_role_by_id(self, gl, group_for_function, users, random_string):

--- a/tests/acceptance/ultimate/test_group_members.py
+++ b/tests/acceptance/ultimate/test_group_members.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from gitlabform import EXIT_PROCESSING_ERROR
@@ -89,7 +91,7 @@ class TestGroupMembers:
         assert member.member_role["base_access_level"] == base_access_level
 
     def test__cannot_add_user_to_group_members_with_custom_role_where_custom_role_does_not_exist(
-        self, gl, group_for_function, users, random_string, capsys
+        self, gl, group_for_function, users, random_string, caplog
     ):
         base_access_level = AccessLevel.REPORTER.value
 
@@ -103,13 +105,13 @@ class TestGroupMembers:
                           member_role: {random_string.lower()}
                 """
 
-        with pytest.raises(SystemExit) as exception:
-            run_gitlabform(add_users, group_for_function)
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(SystemExit) as exception:
+                run_gitlabform(add_users, group_for_function)
 
         assert exception.type == SystemExit
         assert exception.value.code == EXIT_PROCESSING_ERROR
-        captured = capsys.readouterr()
-        assert f"Member Role with name or id {random_string} could not be found" in captured.err
+        assert f"Member Role with name or id {random_string} could not be found" in caplog.text
 
     def _create_custom_role(self, gl, base_access_level, random_string):
         # Python-Gitlab does not directly support Member Roles

--- a/tests/acceptance/ultimate/test_group_settings.py
+++ b/tests/acceptance/ultimate/test_group_settings.py
@@ -2,7 +2,7 @@ import pytest
 
 from tests.acceptance import run_gitlabform
 
-pytestmark = pytest.mark.requires_license
+pytestmark = pytest.mark.requires_ultimate_license
 
 
 class TestGroupSettings:

--- a/tests/acceptance/ultimate/test_members.py
+++ b/tests/acceptance/ultimate/test_members.py
@@ -6,6 +6,8 @@ from tests.acceptance import (
     run_gitlabform,
 )
 
+pytestmark = pytest.mark.requires_ultimate_license
+
 
 class TestMembers:
 

--- a/tests/acceptance/ultimate/test_members.py
+++ b/tests/acceptance/ultimate/test_members.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from gitlabform import EXIT_PROCESSING_ERROR
@@ -105,7 +107,7 @@ class TestMembers:
         assert member.member_role["base_access_level"] == base_access_level
 
     def test__cannot_add_user_to_project_with_custom_role_where_custom_role_does_not_exist(
-        self, gl, group, project_for_function, outsider_user, random_string, capsys
+        self, gl, group, project_for_function, outsider_user, random_string, caplog
     ):
         base_access_level = AccessLevel.REPORTER.value
 
@@ -122,16 +124,16 @@ class TestMembers:
                      member_role: {random_string}
            """
 
-        with pytest.raises(SystemExit) as exception:
-            run_gitlabform(add_users, project_for_function)
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(SystemExit) as exception:
+                run_gitlabform(add_users, project_for_function)
 
         assert exception.type == SystemExit
         assert exception.value.code == EXIT_PROCESSING_ERROR
-        captured = capsys.readouterr()
-        assert f"Member Role with name or id {random_string} could not be found" in captured.err
+        assert f"Member Role with name or id {random_string} could not be found" in caplog.text
 
     def test__cannot_add_user_to_project_with_different_access_than_base_custom_role(
-        self, gl, group, project_for_function, outsider_user, random_string, capsys
+        self, gl, group, project_for_function, outsider_user, random_string, caplog
     ):
         base_access_level = AccessLevel.MAINTAINER.value
         member_role_id = self._create_custom_role(gl, base_access_level, random_string)
@@ -149,16 +151,16 @@ class TestMembers:
                      member_role: {member_role_id}
            """
 
-        with pytest.raises(SystemExit) as exception:
-            run_gitlabform(add_users, project_for_function)
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(SystemExit) as exception:
+                run_gitlabform(add_users, project_for_function)
 
         assert exception.type == SystemExit
         assert exception.value.code == EXIT_PROCESSING_ERROR
-        captured = capsys.readouterr()
-        assert "the custom role's base access level does not match the current access level" in captured.err
+        assert "the custom role's base access level does not match the current access level" in caplog.text
 
     def test__cannot_add_user_to_project_with_custom_role_but_no_access_level(
-        self, gl, group, project_for_function, outsider_user, random_string, capsys
+        self, gl, group, project_for_function, outsider_user, random_string, caplog
     ):
         base_access_level = AccessLevel.MAINTAINER.value
         member_role_id = self._create_custom_role(gl, base_access_level, random_string)
@@ -175,13 +177,13 @@ class TestMembers:
                      member_role: {member_role_id}
            """
 
-        with pytest.raises(SystemExit) as exception:
-            run_gitlabform(add_users, project_for_function)
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(SystemExit) as exception:
+                run_gitlabform(add_users, project_for_function)
 
         assert exception.type == SystemExit
         assert exception.value.code == EXIT_PROCESSING_ERROR
-        captured = capsys.readouterr()
-        assert "the custom role's base access level does not match the current access level" in captured.err
+        assert "the custom role's base access level does not match the current access level" in caplog.text
 
     def _create_custom_role(self, gl, base_access_level, random_string):
         # Python-Gitlab does not directly support Member Roles

--- a/tests/acceptance/ultimate/test_project_security_settings.py
+++ b/tests/acceptance/ultimate/test_project_security_settings.py
@@ -1,7 +1,11 @@
+import pytest
+
 from tests.acceptance import run_gitlabform
 from gitlabform.processors.project.project_security_settings import (
     ProjectSecuritySettingsProcessor,
 )
+
+pytestmark = pytest.mark.requires_ultimate_license
 
 
 class TestProjectSecuritySettings:

--- a/tests/acceptance/ultimate/test_project_security_settings.py
+++ b/tests/acceptance/ultimate/test_project_security_settings.py
@@ -1,4 +1,6 @@
 import pytest
+from gitlab import Gitlab
+from gitlab.v4.objects import Project
 
 from tests.acceptance import run_gitlabform
 from gitlabform.processors.project.project_security_settings import (
@@ -15,12 +17,16 @@ class TestProjectSecuritySettings:
         projects_and_groups:
           {project.path_with_namespace}:
             project_security_settings:
-              pre_receive_secret_detection_enabled: true
+              secret_push_protection_enabled: true
         """
 
         run_gitlabform(config, project)
 
-        processor = ProjectSecuritySettingsProcessor(gitlab=gl)
-        updated_project_security_settings = processor.get_project_security_settings(project.path_with_namespace)
+        updated_project_security_settings = self.get_project_security_settings(project, gl)
 
-        assert updated_project_security_settings["pre_receive_secret_detection_enabled"] is True
+        assert updated_project_security_settings["secret_push_protection_enabled"] is True
+
+    @staticmethod
+    def get_project_security_settings(project: Project, gl: Gitlab):
+        path = f"/projects/{project.id}/security_settings"
+        return gl.http_get(path)

--- a/tests/acceptance/ultimate/test_project_settings.py
+++ b/tests/acceptance/ultimate/test_project_settings.py
@@ -4,7 +4,7 @@ from gitlab.v4.objects import Project, Group
 
 from tests.acceptance import run_gitlabform
 
-pytestmark = pytest.mark.requires_license
+pytestmark = pytest.mark.requires_ultimate_license
 
 
 class TestProjectSettings:

--- a/tests/acceptance/ultimate/test_project_settings.py
+++ b/tests/acceptance/ultimate/test_project_settings.py
@@ -8,6 +8,12 @@ pytestmark = pytest.mark.requires_ultimate_license
 
 
 class TestProjectSettings:
+    @pytest.mark.skip(
+        reason=(
+            "GitLab Duo is only available now to instances with a synchronized subscription, which our Free "
+            "Trial Ultimate keys will not have"
+        )
+    )
     def test__can_set_duo_features_enabled(
         self, gl: Gitlab, gl_graphql: GraphQL, group: Group, project: Project, other_project: Project
     ) -> None:


### PR DESCRIPTION
- requires_license fixture will skip tests if license is expired anyway, as this could be hiding real errors
- fail acceptance tests if license has expired, this should give us quick feedback when we need to request a new one for tests in CI