### PR TITLE
build: switch Dependabot to uv ecosystem and add dependency grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,46 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
     groups:
-      python-gitlab:
+      # Group dependencies by their type (testing, linting, documentation, release tools)
+      # to avoid overwhelming PRs and to allow for more focused updates.
+      # The patterns are based on the names of the dependencies as they appear in the pyproject.toml file
+      # and how they are grouped in the uv configuration.
+      # Dependencies that match the patterns will be grouped together in the same PR.
+       testing:
         patterns:
-          - "python-gitlab*"
+          - "pytest*"
+          - "coverage"
+          - "cryptography"
+          - "deepdiff"
+          - "xkcdpass"
+      testing:
+        patterns:
+          - "pytest*"
+          - "coverage"
+          - "cryptography"
+          - "deepdiff"
+          - "xkcdpass"
+      linting:
+        patterns:
+          - "bandit"
+          - "black"
+          - "codespell"
+          - "mypy*"
+          - "ruff"
+          - "types-*"
+      documentation:
+        patterns:
+          - "markdown*"
+          - "mkdocs*"
+          - "pygments*"
+      release-tools:
+        patterns:
+          - "check-wheel-contents"
+          - "twine"
+          - "commitizen"
+          - "prek"


### PR DESCRIPTION
Currently dependabot uses `pip` for updating dependency versions. The project was recently migrated to `uv` that uses `uv.lock` file for consistent build. Dependabot config needs to be updated to use `uv` so that it will update the lock file accordingly. List of changes in this PR include:

- Change package-ecosystem from 'pip' to 'uv' to enable native support for updating uv.lock and PEP 735 dependency groups.
- Introduce grouping for non-runtime dependencies (testing, linting, documentation, and release tools) to reduce PR noise and CI resource usage.
- Keep runtime dependencies as individual updates to simplify debugging and isolation of any CI failures.