### PR TITLE
build: fix dependabot configuration issue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,13 +23,6 @@ updates:
       # The patterns are based on the names of the dependencies as they appear in the pyproject.toml file
       # and how they are grouped in the uv configuration.
       # Dependencies that match the patterns will be grouped together in the same PR.
-       testing:
-        patterns:
-          - "pytest*"
-          - "coverage"
-          - "cryptography"
-          - "deepdiff"
-          - "xkcdpass"
       testing:
         patterns:
           - "pytest*"
@@ -49,7 +42,8 @@ updates:
         patterns:
           - "markdown*"
           - "mkdocs*"
-          - "pygments*"
+          - "pygments"
+          - "pymdown-extensions"
       release-tools:
         patterns:
           - "check-wheel-contents"


### PR DESCRIPTION
This change fixes a mis-configuration with the dependabot's yaml config file updated in an earlier change, which made dependabot not able to properly parse the config.
