### PR TITLE
build(ci): replace unsupported `uv pip download` with `uv pip install --dry-run`

### DIFF
--- a/.github/workflows/_releases.yml
+++ b/.github/workflows/_releases.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+  # Allow manual triggering of the workflow
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -122,8 +124,10 @@ jobs:
         run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
       - name: Wait for PyPI release
         run: |
-          uv pip download gitlabform==${{ env.VERSION }} > /dev/null
-          while [ $? -ne 0 ]; do sleep 10; uv pip download gitlabform==${{ env.VERSION }} > /dev/null ; done
+          until uv pip install gitlabform==${{ env.VERSION }} --dry-run > /dev/null 2>&1; do
+            echo "Waiting for gitlabform==${{ env.VERSION }} to be available on PyPI..."
+            sleep 10
+          done
         shell: bash {0}
       - name: Docker metadata
         id: metadata


### PR DESCRIPTION
Currently release v5.4.0 and v5.5.0 published to pypi but hasn't published to ghcr yet. 

- [GitLabForm releases on PyPi](https://pypi.org/project/gitlabform/#history)
- [GitLabForm releases on ghcr](https://github.com/gitlabform/gitlabform/pkgs/container/gitlabform)


The `uv pip` interface does not support the `download` subcommand. That's why the release workflow failed in the ghcr publishing step because it has tries to check for release existence in pypi first but keep failing.

This change replaces the PyPI availability check with `uv pip install --dry-run`, which effectively verifies the package's existence on the registry without performing a full installation.

Additionally, `workflow_dispatch` was added to the release workflow to allow manual triggering for tags that failed to publish to GHCR.

After merging this PR, we can do the following:

Since `workflow_dispatch` is added to `_releases.yml` workflow, we can now manually trigger the process for those specific release tags without creating new ones:

- Navigate to the Actions Tab
- Select the Workflow: On the left sidebar, select the Releases workflow.
- Run Workflow: Click the Run workflow dropdown button on the right.
- Choose the Tag: In the Use workflow from dropdown, search for and select the tag we want to fix (e.g., v5.4.0).
- Trigger: Click the green Run workflow button.

@TimKnight01 - could you kindly review/validate? Thank you.

fixes #1290 
