### PR TITLE
feat: allow groups to stop section propagation to descendants

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -162,7 +162,7 @@ projects_and_groups:
   group_1/*:
     project_settings:
       visibility: private # <-- different value!
-``` 
+```
 With this configuration, for a project `group_1/project_1` the effective configuration will be like:
 ```yaml
 project_settings:
@@ -181,7 +181,7 @@ projects_and_groups:
         key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDB2QKx6BPzL...
         title: global_key
         can_push: false
-  
+
   group_1/*:
     deploy_keys:
       key_b: # <-- another key under deploy_keys!
@@ -279,6 +279,57 @@ deploy_keys:
 !!! important
 
     `inherit: false` can be placed at ANY place in the configuration (if it makes sense).
+
+### Stopping propagation to descendants
+
+You can also apply a section at the current level while preventing that same section from flowing further down the hierarchy by placing `propagate: false` under that section.
+
+Example:
+
+```yaml
+projects_and_groups:
+  team_a/*:
+    variables:
+      propagate: false
+      team_secret:
+        key: TEAM_SECRET
+        value: team-value
+```
+
+For the above configuration:
+
+- group `team_a` gets the `variables` section,
+- subgroup `team_a/subgroup_1` does not inherit that `variables` section,
+- project `team_a/project_1` does not inherit that `variables` section either.
+
+A deeper level can define the same section locally to start a new inheritance source for its own subtree:
+
+```yaml
+projects_and_groups:
+  team_a/*:
+    variables:
+      propagate: false
+      team_secret:
+        key: TEAM_SECRET
+        value: team-value
+
+  team_a/subgroup_1/*:
+    variables:
+      subgroup_secret:
+        key: SUBGROUP_SECRET
+        value: subgroup-value
+```
+
+With this configuration, `team_a/subgroup_1` and projects below it inherit only `subgroup_secret`.
+
+!!! important
+
+    `propagate: false` is supported in the same configuration locations where `inherit: false` is supported.
+
+Comparison:
+
+- `inherit: false` means: "this level does not inherit the section from above"
+- `propagate: false` means: "this level applies the section here, but does not pass it further down"
 
 ### Skipping sections
 

--- a/gitlabform/configuration/common.py
+++ b/gitlabform/configuration/common.py
@@ -1,6 +1,6 @@
 from abc import ABC
 
-from gitlabform.configuration.core import ConfigurationCore
+from gitlabform.configuration.core import ConfigurationCore, ConfigurationState
 
 
 class ConfigurationCommon(ConfigurationCore, ABC):
@@ -12,8 +12,15 @@ class ConfigurationCommon(ConfigurationCore, ABC):
         """
         :return: literal common configuration or empty dict if not defined
         """
+        return self._get_common_state().effective_config
+
+    def _get_common_state(self) -> ConfigurationState:
+        """
+        Return the effective and propagatable state for the common ``*`` config.
+        """
         common_config = self.get("projects_and_groups|*", {})
         if common_config:
             section_name = "*"
             self._validate_break_inheritance_flag(common_config, section_name)
-        return common_config
+
+        return self._build_configuration_state({}, common_config)

--- a/gitlabform/configuration/core.py
+++ b/gitlabform/configuration/core.py
@@ -1,5 +1,6 @@
 import sys
 from typing import Any
+from dataclasses import dataclass
 
 import os
 import logging
@@ -19,6 +20,19 @@ from yamlpath.wrappers import ConsolePrinter
 
 from gitlabform.constants import EXIT_INVALID_INPUT
 from ruamel.yaml.comments import CommentedMap
+
+
+@dataclass(frozen=True)
+class ConfigurationState:
+    """
+    Internal configuration state for a single hierarchy node.
+
+    ``effective_config`` is the configuration that applies to the current node.
+    ``propagatable_config`` is the inheritance payload that may flow further down.
+    """
+
+    effective_config: dict
+    propagatable_config: dict
 
 
 class ConfigurationCore(ABC):
@@ -167,6 +181,23 @@ class ConfigurationCore(ABC):
                 ConfigurationCore._validate_break_inheritance_flag(value, section_name, key)
 
     @staticmethod
+    def _validate_propagation_break_flag(config: dict) -> None:
+        """
+        Validate that every ``propagate`` flag uses the supported ``false`` value.
+
+        The traversal intentionally mirrors the recursive traversal used by
+        ``inherit: false`` support so that both control flags are interpreted
+        across the same configuration shapes.
+        """
+        for key, value in config.items():
+            if key == "propagate":
+                if value is not False:
+                    critical("Cannot set the propagation break flag with a value other than false\n")
+                    sys.exit(EXIT_INVALID_INPUT)
+            elif type(value) in [CommentedMap, dict]:
+                ConfigurationCore._validate_propagation_break_flag(value)
+
+    @staticmethod
     def _merge_configs(more_general_config, more_specific_config) -> dict:
         """
         :return: merge more general config with more specific configs.
@@ -214,6 +245,196 @@ class ConfigurationCore(ABC):
         break_inheritance(more_specific_config)
 
         return dict(merged_dict)
+
+    @staticmethod
+    def _remove_control_flags(config: dict) -> dict:
+        """
+        Return a deep copy of ``config`` without propagation control flags.
+
+        The returned structure is safe to expose to processors because it no
+        longer contains ``inherit`` or ``propagate`` implementation details.
+        """
+        if type(config) not in [CommentedMap, dict]:
+            return deepcopy(config)
+
+        cleaned_config = {}
+        for key, value in config.items():
+            if key in ["inherit", "propagate"]:
+                continue
+
+            if type(value) in [CommentedMap, dict]:
+                cleaned_config[key] = ConfigurationCore._remove_control_flags(value)
+            else:
+                cleaned_config[key] = deepcopy(value)
+
+        return cleaned_config
+
+    @staticmethod
+    def _remove_non_propagatable_control_flags(config: dict) -> dict:
+        """
+        Return a deep copy of ``config`` without control flags that must not
+        flow to descendants.
+
+        Unlike ``_remove_control_flags()``, this also strips ``skip`` because
+        skipping is a decision for the current entity only and must not become
+        part of descendant inheritance payloads.
+        """
+        if type(config) not in [CommentedMap, dict]:
+            return deepcopy(config)
+
+        cleaned_config = {}
+        for key, value in config.items():
+            if key in ["inherit", "propagate", "skip"]:
+                continue
+
+            if type(value) in [CommentedMap, dict]:
+                cleaned_config[key] = ConfigurationCore._remove_non_propagatable_control_flags(value)
+            else:
+                cleaned_config[key] = deepcopy(value)
+
+        return cleaned_config
+
+    @staticmethod
+    def _remove_section_at_path(config: dict, path: tuple[str, ...]) -> None:
+        """
+        Remove the section at ``path`` from ``config`` if it exists.
+        """
+        if not path:
+            return
+
+        target_config = config
+        for key in path[:-1]:
+            if key not in target_config or type(target_config[key]) not in [CommentedMap, dict]:
+                return
+            target_config = target_config[key]
+
+        target_config.pop(path[-1], None)
+
+    @staticmethod
+    def _get_section_at_path(config: dict, path: tuple[str, ...]):
+        """
+        Return the config section at ``path`` or ``None`` if it does not exist.
+        """
+        current = config
+        for key in path:
+            if type(current) not in [CommentedMap, dict] or key not in current:
+                return None
+            current = current[key]
+
+        return current
+
+    @staticmethod
+    def _collect_non_propagating_sections(config: dict, parent_path: tuple[str, ...] = ()) -> set[tuple[str, ...]]:
+        """
+        Collect section paths that declare ``propagate: false``.
+
+        Paths are recorded for the mapping section that owns the flag, not for
+        the ``propagate`` key itself, so they can be removed from descendant
+        inheritance payloads later.
+        """
+        blocked_paths = set()
+
+        if type(config) not in [CommentedMap, dict]:
+            return blocked_paths
+
+        for key, value in config.items():
+            if key == "propagate":
+                blocked_paths.add(parent_path)
+            elif type(value) in [CommentedMap, dict]:
+                blocked_paths.update(
+                    ConfigurationCore._collect_non_propagating_sections(
+                        value,
+                        parent_path + (key,),
+                    )
+                )
+
+        return blocked_paths
+
+    @staticmethod
+    def _has_local_section_definition(section_config: dict) -> bool:
+        """
+        Return whether ``section_config`` contains a meaningful local definition.
+
+        A section only reopens propagation if, after removing control keys, at
+        least one non-control key remains.
+        """
+        if type(section_config) not in [CommentedMap, dict]:
+            return False
+
+        for key in section_config.keys():
+            if key not in ["inherit", "propagate", "skip"]:
+                return True
+
+        return False
+
+    @staticmethod
+    def _build_propagatable_config(
+        inherited_config: dict,
+        merged_config: dict,
+        local_config: dict,
+    ) -> dict:
+        """
+        Build the inheritance payload to pass from the current node downward.
+
+        The payload starts from the cleaned merged result and then removes
+        sections explicitly blocked by ``propagate: false``. Sections containing
+        only control flags, such as a lone ``skip: true``, do not reopen
+        propagation when there was no inherited section to propagate.
+        """
+        propagatable_config = ConfigurationCore._remove_non_propagatable_control_flags(merged_config)
+
+        for blocked_path in ConfigurationCore._collect_non_propagating_sections(local_config):
+            ConfigurationCore._remove_section_at_path(propagatable_config, blocked_path)
+
+        for path in ConfigurationCore._collect_section_paths(local_config):
+            local_section = ConfigurationCore._get_section_at_path(local_config, path)
+            inherited_section = ConfigurationCore._get_section_at_path(inherited_config, path)
+
+            if ConfigurationCore._has_local_section_definition(local_section):
+                continue
+
+            if inherited_section is None:
+                ConfigurationCore._remove_section_at_path(propagatable_config, path)
+
+        return propagatable_config
+
+    @staticmethod
+    def _collect_section_paths(config: dict, parent_path: tuple[str, ...] = ()) -> set[tuple[str, ...]]:
+        """
+        Collect paths for every mapping section in ``config``.
+        """
+        paths = set()
+
+        if type(config) not in [CommentedMap, dict]:
+            return paths
+
+        for key, value in config.items():
+            if type(value) in [CommentedMap, dict]:
+                current_path = parent_path + (key,)
+                paths.add(current_path)
+                paths.update(ConfigurationCore._collect_section_paths(value, current_path))
+
+        return paths
+
+    @staticmethod
+    def _build_configuration_state(inherited_config: dict, local_config: dict) -> ConfigurationState:
+        """
+        Build the effective and propagatable configuration for one hierarchy node.
+        """
+        ConfigurationCore._validate_propagation_break_flag(local_config)
+
+        merged_config = ConfigurationCore._merge_configs(inherited_config, local_config)
+        effective_config = ConfigurationCore._remove_control_flags(merged_config)
+        propagatable_config = ConfigurationCore._build_propagatable_config(
+            inherited_config,
+            merged_config,
+            local_config,
+        )
+
+        return ConfigurationState(
+            effective_config=effective_config,
+            propagatable_config=propagatable_config,
+        )
 
     @staticmethod
     def _get_case_insensitively(a_dict: dict, a_key: str):

--- a/gitlabform/configuration/core.py
+++ b/gitlabform/configuration/core.py
@@ -332,7 +332,7 @@ class ConfigurationCore(ABC):
         the ``propagate`` key itself, so they can be removed from descendant
         inheritance payloads later.
         """
-        blocked_paths = set()
+        blocked_paths: set[tuple[str, ...]] = set()
 
         if type(config) not in [CommentedMap, dict]:
             return blocked_paths
@@ -403,7 +403,7 @@ class ConfigurationCore(ABC):
         """
         Collect paths for every mapping section in ``config``.
         """
-        paths = set()
+        paths: set[tuple[str, ...]] = set()
 
         if type(config) not in [CommentedMap, dict]:
             return paths

--- a/gitlabform/configuration/groups.py
+++ b/gitlabform/configuration/groups.py
@@ -4,6 +4,7 @@ import functools
 from logging import debug
 
 from gitlabform.configuration import ConfigurationCommon
+from gitlabform.configuration.core import ConfigurationState
 from gitlabform.util import to_str
 
 
@@ -45,27 +46,37 @@ class ConfigurationGroups(ConfigurationCommon, ABC):
             debug(f"Group {group} is skipped, returning empty config")
             return {}
 
-        common_config = self.get_common_config()
-        debug("*Effective* common config: %s", to_str(common_config))
+        group_state = self._get_group_state(group)
+        debug("*Effective* config common+group/subgroup: %s", to_str(group_state.effective_config))
 
-        if "/" in group:
-            group_config = self._get_effective_subgroup_config(group)
-        else:
-            group_config = self._get_group_config(group)
-        debug("*Effective* group/subgroup config: %s", to_str(group_config))
+        return group_state.effective_config
 
-        if not common_config and group_config:
-            self._validate_break_inheritance_flag(group_config, group)
-
-        effective_config_for_group = self._merge_configs(common_config, group_config)
+    @functools.lru_cache()
+    def _get_group_state(self, group) -> ConfigurationState:
         debug(
-            "*Effective* config common+group/subgroup: %s",
-            to_str(effective_config_for_group),
+            "Building group state for '%s'",
+            group,
         )
 
-        return effective_config_for_group
+        common_state = self._get_common_state()
+        debug("*Effective* common config: %s", to_str(common_state.effective_config))
+        debug("*Propagatable* common config: %s", to_str(common_state.propagatable_config))
 
-    def _get_effective_subgroup_config(self, subgroup):
+        if "/" in group:
+            return self._get_effective_subgroup_state(group, common_state)
+
+        group_config = self._get_group_config(group)
+        debug("*Raw* group config: %s", to_str(group_config))
+
+        if not common_state.propagatable_config and group_config:
+            self._validate_break_inheritance_flag(group_config, group)
+
+        return self._build_configuration_state(common_state.propagatable_config, group_config)
+
+    def _get_effective_subgroup_state(self, subgroup: str, common_state: ConfigurationState) -> ConfigurationState:
+        """
+        Return the configuration state for ``subgroup`` across the whole hierarchy.
+        """
         #
         # Goes through a subgroups hierarchy, from top to bottom
         #
@@ -80,14 +91,22 @@ class ConfigurationGroups(ConfigurationCommon, ABC):
         #
         # ...where a = merged_config("x", "x/y") and b = merged_config(a, "x/y/z")
         #
-
-        effective_config = {}
         elements = subgroup.split("/")
         last_element = None
+        inherited_state = common_state
+
         for element in elements:
             if not last_element:
-                effective_config = self._get_group_config(element)
-                debug("First level config for '%s': %s", element, to_str(effective_config))
+                first_level_group_config = self._get_group_config(element)
+                debug("First level config for '%s': %s", element, to_str(first_level_group_config))
+
+                if not inherited_state.propagatable_config and first_level_group_config:
+                    self._validate_break_inheritance_flag(first_level_group_config, element)
+
+                inherited_state = self._build_configuration_state(
+                    inherited_state.propagatable_config,
+                    first_level_group_config,
+                )
                 last_element = element
             else:
                 next_level_subgroup = last_element + "/" + element
@@ -98,24 +117,22 @@ class ConfigurationGroups(ConfigurationCommon, ABC):
                     to_str(next_level_subgroup_config),
                 )
 
-                if effective_config:
-                    self._validate_break_inheritance_flag(effective_config, subgroup)
-                elif not effective_config and next_level_subgroup_config:
+                if not inherited_state.propagatable_config and next_level_subgroup_config:
                     self._validate_break_inheritance_flag(next_level_subgroup_config, next_level_subgroup)
 
-                effective_config = self._merge_configs(
-                    effective_config,
+                inherited_state = self._build_configuration_state(
+                    inherited_state.propagatable_config,
                     next_level_subgroup_config,
                 )
                 debug(
                     "Merged previous level config for '%s' with config for '%s': %s",
                     last_element,
                     next_level_subgroup,
-                    to_str(effective_config),
+                    to_str(inherited_state.effective_config),
                 )
-                last_element = last_element + "/" + element
+                last_element = next_level_subgroup
 
-        return effective_config
+        return inherited_state
 
     def _get_group_config(self, group) -> dict:
         """

--- a/gitlabform/configuration/projects.py
+++ b/gitlabform/configuration/projects.py
@@ -45,24 +45,26 @@ class ConfigurationProjects(ConfigurationGroups, ABC):
 
         group, _ = group_and_project.rsplit("/", 1)
 
-        effective_config_for_group = self.get_effective_config_for_group(group)
+        group_state = self._get_group_state(group)
+        debug("*Effective* group config for project inheritance: %s", to_str(group_state.effective_config))
+        debug("*Propagatable* group config for project inheritance: %s", to_str(group_state.propagatable_config))
 
         project_config = self._get_project_config(group_and_project)
         debug("Project config: %s", to_str(project_config))
 
-        if not effective_config_for_group and project_config:
+        if not group_state.propagatable_config and project_config:
             self._validate_break_inheritance_flag(project_config, group_and_project)
 
-        effective_config_for_project = self._merge_configs(
-            effective_config_for_group,
+        project_state = self._build_configuration_state(
+            group_state.propagatable_config,
             project_config,
         )
         debug(
             "*Effective* config common+group/subgroup+project: %s",
-            to_str(effective_config_for_project),
+            to_str(project_state.effective_config),
         )
 
-        return effective_config_for_project
+        return project_state.effective_config
 
     def _get_project_config(self, group_and_project) -> dict:
         """

--- a/tests/acceptance/standard/test_project_variables.py
+++ b/tests/acceptance/standard/test_project_variables.py
@@ -5,7 +5,7 @@ from logging import info  # for wraps
 from unittest.mock import patch
 from gitlab.exceptions import GitlabListError
 
-from tests.acceptance import run_gitlabform
+from tests.acceptance import create_project, run_gitlabform
 
 
 class TestVariables:
@@ -523,3 +523,62 @@ class TestVariables:
         assert variables[1].value == "456_updated"
         assert variables[2].key == "QUX"
         assert variables[2].value == "new"
+
+
+class TestVariablesPropagation:
+    def test__group_level_propagation_break__direct_project_does_not_inherit_variables(
+        self,
+        group_for_function,
+    ):
+        project = create_project(group_for_function, "propagation_break_direct_project")
+        try:
+            config = f"""
+            projects_and_groups:
+              {group_for_function.full_path}/*:
+                variables:
+                  propagate: false
+                  blocked_variable:
+                    key: BLOCKED_VARIABLE
+                    value: blocked-value
+            """
+
+            run_gitlabform(config, group_for_function.full_path)
+
+            variables = project.variables.list(get_all=True)
+
+            assert len(variables) == 0
+        finally:
+            project.delete()
+
+    def test__common_level_propagation_break__subgroup_local_redefinition_flows_to_projects_below(
+        self,
+        group_for_function,
+        subgroup_for_function,
+    ):
+        project = create_project(subgroup_for_function, "propagation_break_subgroup_project")
+        try:
+            config = f"""
+            projects_and_groups:
+              "*":
+                variables:
+                  propagate: false
+                  global_variable:
+                    key: GLOBAL_VARIABLE
+                    value: global-value
+
+              {subgroup_for_function.full_path}/*:
+                variables:
+                  local_variable:
+                    key: LOCAL_VARIABLE
+                    value: local-value
+            """
+
+            run_gitlabform(config, group_for_function.full_path)
+
+            variables = project.variables.list(get_all=True)
+
+            assert len(variables) == 1
+            assert variables[0].key == "LOCAL_VARIABLE"
+            assert variables[0].value == "local-value"
+        finally:
+            project.delete()

--- a/tests/unit/configuration/test_propagation_break_groups_and_projects.py
+++ b/tests/unit/configuration/test_propagation_break_groups_and_projects.py
@@ -1,0 +1,238 @@
+from gitlabform.configuration import Configuration
+
+
+class TestPropagationBreakGroupsAndProjects:
+    def test__propagation_break__flag_set_at_group_level__subgroup_does_not_inherit_section(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          some_group/*:
+            variables:
+              propagate: false
+              secret1:
+                key: foo
+                value: bar
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_config = configuration.get_effective_config_for_group("some_group/some_subgroup")
+
+        assert effective_config == {}
+
+    def test__propagation_break__flag_set_at_group_level__project_does_not_inherit_section(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          some_group/*:
+            variables:
+              propagate: false
+              secret1:
+                key: foo
+                value: bar
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_config = configuration.get_effective_config_for_project("some_group/some_project")
+
+        assert effective_config == {}
+
+    def test__propagation_break__flag_set_at_group_level__group_still_gets_its_own_section(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          some_group/*:
+            variables:
+              propagate: false
+              secret1:
+                key: foo
+                value: bar
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_config = configuration.get_effective_config_for_group("some_group")
+
+        assert effective_config == {
+            "variables": {
+                "secret1": {
+                    "key": "foo",
+                    "value": "bar",
+                }
+            }
+        }
+
+    def test__propagation_break__common_level_flag_blocks_global_inheritance_until_local_redefinition(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          "*":
+            variables:
+              propagate: false
+              global_secret:
+                key: foo
+                value: bar
+
+          some_group/*:
+            variables:
+              local_secret:
+                key: fizz
+                value: buzz
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_group_config = configuration.get_effective_config_for_group("some_group")
+        effective_project_config = configuration.get_effective_config_for_project("some_group/some_project")
+
+        expected_variables = {
+            "local_secret": {
+                "key": "fizz",
+                "value": "buzz",
+            }
+        }
+
+        assert effective_group_config == {"variables": expected_variables}
+        assert effective_project_config == {"variables": expected_variables}
+
+    def test__propagation_break__common_level_flag_blocks_groups_and_projects_without_local_redefinition(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          "*":
+            variables:
+              propagate: false
+              global_secret:
+                key: foo
+                value: bar
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_group_config = configuration.get_effective_config_for_group("some_group")
+        effective_project_config = configuration.get_effective_config_for_project("some_group/some_project")
+
+        assert effective_group_config == {}
+        assert effective_project_config == {}
+
+    def test__propagation_break__common_level_local_redefinition_in_subgroup_reopens_for_deeper_project(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          "*":
+            variables:
+              propagate: false
+              global_secret:
+                key: foo
+                value: bar
+
+          some_group/some_subgroup/*:
+            variables:
+              subgroup_secret:
+                key: fizz
+                value: buzz
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_subgroup_config = configuration.get_effective_config_for_group("some_group/some_subgroup")
+        effective_project_config = configuration.get_effective_config_for_project(
+            "some_group/some_subgroup/some_project"
+        )
+
+        expected_variables = {
+            "subgroup_secret": {
+                "key": "fizz",
+                "value": "buzz",
+            }
+        }
+
+        assert effective_subgroup_config == {"variables": expected_variables}
+        assert effective_project_config == {"variables": expected_variables}
+
+    def test__propagation_break__local_redefinition_reopens_propagation_for_descendants(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          some_group/*:
+            variables:
+              propagate: false
+              secret1:
+                key: foo
+                value: bar
+
+          some_group/some_subgroup/*:
+            variables:
+              secret2:
+                key: fizz
+                value: buzz
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_subgroup_config = configuration.get_effective_config_for_group("some_group/some_subgroup")
+        effective_project_config = configuration.get_effective_config_for_project(
+            "some_group/some_subgroup/some_project"
+        )
+
+        expected_variables = {
+            "secret2": {
+                "key": "fizz",
+                "value": "buzz",
+            }
+        }
+
+        assert effective_subgroup_config == {"variables": expected_variables}
+        assert effective_project_config == {"variables": expected_variables}
+
+    def test__propagation_break__skip_alone_does_not_reopen_propagation(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          some_group/*:
+            variables:
+              propagate: false
+              secret1:
+                key: foo
+                value: bar
+
+          some_group/some_subgroup/*:
+            variables:
+              skip: true
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_subgroup_config = configuration.get_effective_config_for_group("some_group/some_subgroup")
+        effective_project_config = configuration.get_effective_config_for_project(
+            "some_group/some_subgroup/some_project"
+        )
+
+        assert effective_subgroup_config == {"variables": {"skip": True}}
+        assert effective_project_config == {}
+
+    def test__propagation_break__skip_only_affects_current_entity_when_section_is_not_blocked(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          some_group/*:
+            variables:
+              secret1:
+                key: foo
+                value: bar
+
+          some_group/some_subgroup/*:
+            variables:
+              skip: true
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_subgroup_config = configuration.get_effective_config_for_group("some_group/some_subgroup")
+        effective_project_config = configuration.get_effective_config_for_project(
+            "some_group/some_subgroup/some_project"
+        )
+
+        assert effective_subgroup_config == {"variables": {"secret1": {"key": "foo", "value": "bar"}, "skip": True}}
+        assert effective_project_config == {"variables": {"secret1": {"key": "foo", "value": "bar"}}}

--- a/tests/unit/configuration/test_propagation_break_subgroups.py
+++ b/tests/unit/configuration/test_propagation_break_subgroups.py
@@ -1,0 +1,178 @@
+from gitlabform.configuration import Configuration
+
+
+class TestPropagationBreakSubgroups:
+    def test__propagation_break__flag_set_at_subgroup_level__deeper_subgroup_does_not_inherit_section(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          some_group/*:
+            project_settings:
+              root: value
+
+          some_group/some_subgroup/*:
+            project_settings:
+              propagate: false
+              subgroup: value
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_config = configuration.get_effective_config_for_group("some_group/some_subgroup/deeper_subgroup")
+
+        assert effective_config == {}
+
+    def test__propagation_break__flag_set_at_subgroup_level__deeper_project_does_not_inherit_section(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          some_group/*:
+            project_settings:
+              root: value
+
+          some_group/some_subgroup/*:
+            project_settings:
+              propagate: false
+              subgroup: value
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_config = configuration.get_effective_config_for_project("some_group/some_subgroup/some_project")
+
+        assert effective_config == {}
+
+    def test__propagation_break__inherit_and_propagate_can_coexist_on_same_section(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          "*":
+            variables:
+              common_secret:
+                key: foo
+                value: bar
+
+          some_group/*:
+            variables:
+              inherit: false
+              propagate: false
+              group_secret:
+                key: fizz
+                value: buzz
+
+          some_group/some_subgroup/*:
+            variables:
+              subgroup_secret:
+                key: zap
+                value: zip
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_group_config = configuration.get_effective_config_for_group("some_group")
+        effective_subgroup_config = configuration.get_effective_config_for_group("some_group/some_subgroup")
+        effective_project_config = configuration.get_effective_config_for_project(
+            "some_group/some_subgroup/some_project"
+        )
+
+        assert effective_group_config == {
+            "variables": {
+                "group_secret": {
+                    "key": "fizz",
+                    "value": "buzz",
+                }
+            }
+        }
+        assert effective_subgroup_config == {
+            "variables": {
+                "subgroup_secret": {
+                    "key": "zap",
+                    "value": "zip",
+                }
+            }
+        }
+        assert effective_project_config == {
+            "variables": {
+                "subgroup_secret": {
+                    "key": "zap",
+                    "value": "zip",
+                }
+            }
+        }
+
+    def test__propagation_break__descendant_local_redefinition_reopens_for_deeper_subtree(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          some_group/*:
+            variables:
+              propagate: false
+              root_secret:
+                key: ROOT_SECRET
+                value: root-value
+
+          some_group/subgroup_level_1/*:
+            variables:
+              subgroup_secret:
+                key: SUBGROUP_SECRET
+                value: subgroup-value
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_deeper_subgroup_config = configuration.get_effective_config_for_group(
+            "some_group/subgroup_level_1/subgroup_level_2"
+        )
+        effective_deeper_project_config = configuration.get_effective_config_for_project(
+            "some_group/subgroup_level_1/subgroup_level_2/some_project"
+        )
+
+        expected_variables = {
+            "subgroup_secret": {
+                "key": "SUBGROUP_SECRET",
+                "value": "subgroup-value",
+            }
+        }
+
+        assert effective_deeper_subgroup_config == {"variables": expected_variables}
+        assert effective_deeper_project_config == {"variables": expected_variables}
+
+    def test__propagation_break__descendant_redefinition_can_block_again_for_its_own_descendants(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          some_group/*:
+            variables:
+              propagate: false
+              root_secret:
+                key: ROOT_SECRET
+                value: root-value
+
+          some_group/subgroup_level_1/*:
+            variables:
+              propagate: false
+              subgroup_secret:
+                key: SUBGROUP_SECRET
+                value: subgroup-value
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        effective_subgroup_config = configuration.get_effective_config_for_group("some_group/subgroup_level_1")
+        effective_deeper_subgroup_config = configuration.get_effective_config_for_group(
+            "some_group/subgroup_level_1/subgroup_level_2"
+        )
+        effective_deeper_project_config = configuration.get_effective_config_for_project(
+            "some_group/subgroup_level_1/subgroup_level_2/some_project"
+        )
+
+        assert effective_subgroup_config == {
+            "variables": {
+                "subgroup_secret": {
+                    "key": "SUBGROUP_SECRET",
+                    "value": "subgroup-value",
+                }
+            }
+        }
+        assert effective_deeper_subgroup_config == {}
+        assert effective_deeper_project_config == {}

--- a/tests/unit/configuration/test_propagation_break_validation.py
+++ b/tests/unit/configuration/test_propagation_break_validation.py
@@ -1,0 +1,44 @@
+import pytest
+
+from gitlabform import EXIT_INVALID_INPUT
+from gitlabform.configuration import Configuration
+
+
+class TestPropagationBreakValidation:
+    def test__validate_propagation_break_flag__true_value_is_invalid(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          some_group/*:
+            variables:
+              propagate: true
+              secret:
+                key: foo
+                value: bar
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        with pytest.raises(SystemExit) as exception:
+            configuration.get_effective_config_for_group("some_group")
+        assert exception.type == SystemExit
+        assert exception.value.code == EXIT_INVALID_INPUT
+
+    def test__validate_propagation_break_flag__scalar_value_is_invalid(self):
+        config_yaml = """
+        ---
+        projects_and_groups:
+          some_group/*:
+            variables:
+              propagate: 1
+              secret:
+                key: foo
+                value: bar
+        """
+
+        configuration = Configuration(config_string=config_yaml)
+
+        with pytest.raises(SystemExit) as exception:
+            configuration.get_effective_config_for_group("some_group")
+        assert exception.type == SystemExit
+        assert exception.value.code == EXIT_INVALID_INPUT


### PR DESCRIPTION
# Summary

Add support for parent-side inheritance blocking with `propagate: false`.

This introduces a new configuration control that lets a group or common `*`
section apply configuration at the current level while preventing that same
section from flowing further down to descendant subgroups and projects.

## What Changed

* Added internal propagation-aware configuration state with:
  * `effective_config`
  * `propagatable_config`
* Implemented `propagate: false` handling in the configuration layer for:
  * common `*` config
  * groups and subgroups
  * projects
* Preserved existing `inherit: false` behavior
* Added validation for invalid `propagate` values
* Added unit coverage for:
  * group to subgroup/project blocking
  * subgroup subtree blocking
  * local redefinition reopening propagation
  * coexistence of `inherit: false` and `propagate: false`
  * `skip: true` not reopening propagation by itself
  * invalid `propagate` values
* Added documentation for `propagate: false`
* Added acceptance scenarios for project variables propagation behavior

## Behavior

Example:

```yaml
projects_and_groups:
  team_a/*:
    variables:
      propagate: false
      team_secret:
        key: TEAM_SECRET
        value: team-value
```

With this configuration:

* `team_a` gets `variables`
* `team_a/subgroup_1` does not inherit `variables`
* `team_a/project_1` does not inherit `variables`

If a deeper level defines the same section locally, that local definition
becomes the new propagation source for its subtree unless it also sets
`propagate: false`.

## Implementation Notes

* Public configuration APIs were kept unchanged
* The propagation logic is isolated to the new configuration-state flow
* Existing inheritance-break logic remains in place and is still validated by
  the previous test suite

## Risks / Review Focus

* Review the semantics of subtree-wide blocking when a descendant redefines the
  same section locally;
* Review the interaction between `propagate: false` and existing `skip: true`
  behavior
* Review the common `*` behavior carefully, since it now acts as a propagation
  source that can also be globally blocked
