### PR TITLE
fix: collect subgroup projects for recursive group targets

### DIFF
--- a/gitlabform/lists/projects.py
+++ b/gitlabform/lists/projects.py
@@ -40,7 +40,7 @@ class ProjectsProvider(GroupsProvider):
         groups = self.get_groups(target)
 
         if target not in ["ALL", "ALL_DEFINED"]:
-            if len(groups.get_effective()) == 1:
+            if groups.get_effective():
                 projects = self._get_projects(target, groups)
             else:
                 projects = self._get_single_project(target)

--- a/tests/acceptance/standard/test_project_variables.py
+++ b/tests/acceptance/standard/test_project_variables.py
@@ -531,7 +531,10 @@ class TestVariablesRegression:
         group_for_function,
         subgroup_for_function,
     ):
-        project = create_project(subgroup_for_function, "descendant_subgroup_project")
+        project = create_project(
+            subgroup_for_function,
+            "descendant_subgroup_project",
+        )
         try:
             config = f"""
             projects_and_groups:

--- a/tests/acceptance/standard/test_project_variables.py
+++ b/tests/acceptance/standard/test_project_variables.py
@@ -5,7 +5,7 @@ from logging import info  # for wraps
 from unittest.mock import patch
 from gitlab.exceptions import GitlabListError
 
-from tests.acceptance import run_gitlabform
+from tests.acceptance import create_project, run_gitlabform
 
 
 class TestVariables:
@@ -523,3 +523,31 @@ class TestVariables:
         assert variables[1].value == "456_updated"
         assert variables[2].key == "QUX"
         assert variables[2].value == "new"
+
+
+class TestVariablesRegression:
+    def test__running_for_group_target__processes_project_in_descendant_subgroup(
+        self,
+        group_for_function,
+        subgroup_for_function,
+    ):
+        project = create_project(subgroup_for_function, "descendant_subgroup_project")
+        try:
+            config = f"""
+            projects_and_groups:
+              {subgroup_for_function.full_path}/*:
+                variables:
+                  local_variable:
+                    key: LOCAL_VARIABLE
+                    value: local-value
+            """
+
+            run_gitlabform(config, group_for_function.full_path)
+
+            variables = project.variables.list(get_all=True)
+
+            assert len(variables) == 1
+            assert variables[0].key == "LOCAL_VARIABLE"
+            assert variables[0].value == "local-value"
+        finally:
+            project.delete()

--- a/tests/unit/test_projects_provider.py
+++ b/tests/unit/test_projects_provider.py
@@ -282,9 +282,7 @@ class TestGetProjects:
         configuration_mock.is_project_skipped.return_value = False
 
         provider = make_provider(gitlab_mock, configuration_mock)
-        provider.get_groups = MagicMock(
-            return_value=self._make_groups(["group", "group/subgroup"])
-        )
+        provider.get_groups = MagicMock(return_value=self._make_groups(["group", "group/subgroup"]))
 
         projects = provider.get_projects("group")
 

--- a/tests/unit/test_projects_provider.py
+++ b/tests/unit/test_projects_provider.py
@@ -269,6 +269,22 @@ class TestGetProjects:
         groups.add_requested(effective)
         return groups
 
+    def test__group_target_with_recursive_subgroups__uses_group_project_collection(self, gitlab_mock, configuration_mock):
+        gitlab_mock.get_projects.side_effect = [
+            ["group/project1", "group/subgroup/project2"],
+            ["group/subgroup/project2"],
+        ]
+        configuration_mock.get_projects.return_value = []
+        configuration_mock.is_project_skipped.return_value = False
+
+        provider = make_provider(gitlab_mock, configuration_mock)
+        provider.get_groups = MagicMock(return_value=self._make_groups(["group", "group/subgroup"]))
+
+        projects = provider.get_projects("group")
+
+        assert sorted(projects.get_effective()) == ["group/project1", "group/subgroup/project2"]
+        gitlab_mock.get_project_case_insensitive.assert_not_called()
+
     def test__scheduled_for_deletion_added_to_omitted_from_groups(self, gitlab_mock, configuration_mock):
         gitlab_mock.get_projects.return_value = [
             {"path_with_namespace": "group/project1", "archived": False, "marked_for_deletion_on": None},

--- a/tests/unit/test_projects_provider.py
+++ b/tests/unit/test_projects_provider.py
@@ -269,7 +269,11 @@ class TestGetProjects:
         groups.add_requested(effective)
         return groups
 
-    def test__group_target_with_recursive_subgroups__uses_group_project_collection(self, gitlab_mock, configuration_mock):
+    def test__group_target_with_recursive_subgroups__uses_group_project_collection(
+        self,
+        gitlab_mock,
+        configuration_mock,
+    ):
         gitlab_mock.get_projects.side_effect = [
             ["group/project1", "group/subgroup/project2"],
             ["group/subgroup/project2"],
@@ -278,11 +282,16 @@ class TestGetProjects:
         configuration_mock.is_project_skipped.return_value = False
 
         provider = make_provider(gitlab_mock, configuration_mock)
-        provider.get_groups = MagicMock(return_value=self._make_groups(["group", "group/subgroup"]))
+        provider.get_groups = MagicMock(
+            return_value=self._make_groups(["group", "group/subgroup"])
+        )
 
         projects = provider.get_projects("group")
 
-        assert sorted(projects.get_effective()) == ["group/project1", "group/subgroup/project2"]
+        assert sorted(projects.get_effective()) == [
+            "group/project1",
+            "group/subgroup/project2",
+        ]
         gitlab_mock.get_project_case_insensitive.assert_not_called()
 
     def test__scheduled_for_deletion_added_to_omitted_from_groups(self, gitlab_mock, configuration_mock):


### PR DESCRIPTION
This PR fixes project discovery for group targets when subgroup recursion is enabled.

Previously, `ProjectsProvider.get_projects()` used `len(groups.get_effective()) == 1` to decide whether the target should be treated as a group or as a single project. That worked for a group without subgroups, but broke as soon as recursive traversal returned more than one effective group. In that case, GitLabForm incorrectly fell back to `_get_single_project(target)` and skipped projects in descendant subgroups.

The fix changes this decision point to use whether any effective groups were found at all. If `get_groups(target)` returns groups, the target is treated as a group and project collection proceeds through `_get_projects(...)`. Only when no groups are found does GitLabForm fall back to `_get_single_project(target)`.

This PR also adds a regression test covering a group target with recursive subgroup discovery, ensuring subgroup projects are collected through the group path rather than being treated as a single-project target.

Closes #1302