### PR TITLE
fix: group-members-inheritance

### DIFF
--- a/gitlabform/__init__.py
+++ b/gitlabform/__init__.py
@@ -404,6 +404,8 @@ class GitLabForm:
                 exclude_sections=self.exclude_sections,
             )
 
+        self.group_processors.set_effective_groups(groups)
+
         for group in groups:
             group_number += 1
 

--- a/gitlabform/configuration/groups.py
+++ b/gitlabform/configuration/groups.py
@@ -124,3 +124,9 @@ class ConfigurationGroups(ConfigurationCommon, ABC):
                  ignoring the case
         """
         return self._get_case_insensitively(self.get("projects_and_groups"), f"{group}/*")
+
+    def has_group_section_defined_locally(self, group: str, section_name: str) -> bool:
+        """
+        :return: True when ``section_name`` is defined directly on ``group/*`` in the config.
+        """
+        return section_name in self._get_group_config(group)

--- a/gitlabform/processors/group/__init__.py
+++ b/gitlabform/processors/group/__init__.py
@@ -41,7 +41,7 @@ class GroupProcessors(AbstractProcessors):
         self.processors: List[AbstractProcessor] = [
             GroupVariablesProcessor(gitlab),
             GroupSettingsProcessor(gitlab),
-            GroupMembersProcessor(gitlab),
+            GroupMembersProcessor(gitlab, config),
             GroupLDAPLinksProcessor(gitlab),
             GroupBadgesProcessor(gitlab),
             GroupSAMLLinksProcessor(gitlab),
@@ -50,3 +50,8 @@ class GroupProcessors(AbstractProcessors):
             GroupPushRulesProcessor(gitlab),
             GroupProtectedBranchesProcessor(gitlab, strict),
         ]
+
+    def set_effective_groups(self, groups: list[str]) -> None:
+        for processor in self.processors:
+            if hasattr(processor, "set_effective_groups"):
+                processor.set_effective_groups(groups)

--- a/gitlabform/processors/group/group_members_processor.py
+++ b/gitlabform/processors/group/group_members_processor.py
@@ -1,4 +1,5 @@
 import sys
+from collections.abc import Iterable
 from typing import Dict, Tuple
 
 from logging import debug, info, critical, error
@@ -11,8 +12,13 @@ from gitlab import GitlabDeleteError, GitlabError, GitlabGetError
 
 
 class GroupMembersProcessor(AbstractProcessor):
-    def __init__(self, gitlab: GitLab):
+    def __init__(self, gitlab: GitLab, configuration):
         super().__init__("group_members", gitlab)
+        self.configuration = configuration
+        self.effective_groups: set[str] = set()
+
+    def set_effective_groups(self, groups: Iterable[str]) -> None:
+        self.effective_groups = set(groups)
 
     def _process_configuration(self, group_name: str, configuration: dict):
         keep_bots = configuration.get("group_members|keep_bots", False)
@@ -285,3 +291,30 @@ class GroupMembersProcessor(AbstractProcessor):
         for member in members:
             users[member.username.lower()] = member
         return users
+
+    def _can_proceed(self, group_name: str, configuration: dict):
+        if "/" not in group_name:
+            return True
+
+        if self.configuration.has_group_section_defined_locally(group_name, self.configuration_name):
+            return True
+
+        if self._has_ancestor_in_current_run(group_name):
+            info(
+                "Skipping section '%s' for subgroup '%s' because it is inherited from an ancestor group "
+                "that is also being processed in this run.",
+                self.configuration_name,
+                group_name,
+            )
+            return False
+
+        return True
+
+    def _has_ancestor_in_current_run(self, group_name: str) -> bool:
+        current_group = group_name
+        while "/" in current_group:
+            current_group = current_group.rsplit("/", 1)[0]
+            if current_group in self.effective_groups:
+                return True
+
+        return False

--- a/tests/acceptance/standard/test_membership_inheritance.py
+++ b/tests/acceptance/standard/test_membership_inheritance.py
@@ -1,0 +1,193 @@
+import pytest
+
+from gitlabform.gitlab import AccessLevel
+from tests.acceptance import (
+    allowed_codes,
+    create_group,
+    create_project,
+    get_random_name,
+    run_gitlabform,
+)
+
+
+@pytest.fixture(scope="function")
+def root_and_subgroup_projects(group_for_function, subgroup_for_function):
+    root_project = create_project(group_for_function, get_random_name("project"))
+    subgroup_project = create_project(subgroup_for_function, get_random_name("project"))
+
+    yield root_project, subgroup_project
+
+    with allowed_codes(404):
+        subgroup_project.delete()
+
+    with allowed_codes(404):
+        root_project.delete()
+
+
+@pytest.fixture(scope="function")
+def nested_subgroup_for_function(gl, group_for_function, subgroup_for_function):
+    subsubgroup_name = get_random_name("subgroup")
+    gitlab_subsubgroup = create_group(subsubgroup_name, subgroup_for_function.id)
+
+    yield gitlab_subsubgroup
+
+    with allowed_codes(404):
+        gl.groups.delete(f"{group_for_function.full_path}/{subgroup_for_function.path}/{subsubgroup_name}")
+
+
+@pytest.fixture(scope="function")
+def shared_group_for_function(gl):
+    group_name = get_random_name("shared_group")
+    gitlab_group = create_group(group_name)
+
+    yield gitlab_group
+
+    with allowed_codes(404):
+        gl.groups.delete(group_name)
+
+
+class TestMembershipInheritance:
+    def test__group_members_from_parent_group_are_not_added_directly_to_subgroup(
+        self,
+        gl,
+        group_for_function,
+        subgroup_for_function,
+        users_for_function,
+    ):
+        inherited_user = users_for_function[0]
+
+        config = f"""
+        projects_and_groups:
+          {group_for_function.full_path}/*:
+            group_members:
+              users:
+                {inherited_user.username}:
+                  access_level: {AccessLevel.DEVELOPER.value}
+        """
+
+        run_gitlabform(config, group_for_function.full_path)
+
+        refreshed_group = gl.groups.get(group_for_function.id)
+        refreshed_subgroup = gl.groups.get(subgroup_for_function.id)
+
+        root_group_direct_members = [member.username for member in refreshed_group.members.list(get_all=True)]
+        subgroup_direct_members = [member.username for member in refreshed_subgroup.members.list(get_all=True)]
+
+        assert inherited_user.username in root_group_direct_members
+        assert inherited_user.username not in subgroup_direct_members
+
+    def test__members_from_parent_group_are_not_added_directly_to_projects_in_subgroups(
+        self,
+        gl,
+        group_for_function,
+        users_for_function,
+        root_and_subgroup_projects,
+    ):
+        inherited_user = users_for_function[0]
+        _, subgroup_project = root_and_subgroup_projects
+
+        group_for_function.members.create(
+            {
+                "user_id": inherited_user.id,
+                "access_level": AccessLevel.DEVELOPER.value,
+            }
+        )
+
+        config = f"""
+        projects_and_groups:
+          {group_for_function.full_path}/*:
+            members:
+              users:
+                {inherited_user.username}:
+                  access_level: {AccessLevel.DEVELOPER.value}
+        """
+
+        run_gitlabform(config, group_for_function.full_path)
+
+        refreshed_subgroup_project = gl.projects.get(subgroup_project.id)
+
+        subgroup_project_direct_members = [member.username for member in refreshed_subgroup_project.members.list()]
+        subgroup_project_all_members = [member.username for member in refreshed_subgroup_project.members_all.list()]
+
+        assert inherited_user.username not in subgroup_project_direct_members
+        assert inherited_user.username in subgroup_project_all_members
+
+    def test__group_member_groups_from_parent_group_are_not_shared_directly_to_descendants(
+        self,
+        gl,
+        group_for_function,
+        subgroup_for_function,
+        shared_group_for_function,
+    ):
+        config = f"""
+        projects_and_groups:
+          {group_for_function.full_path}/*:
+            group_members:
+              groups:
+                {shared_group_for_function.full_path}:
+                  group_access: {AccessLevel.DEVELOPER.value}
+        """
+
+        run_gitlabform(config, group_for_function.full_path)
+
+        refreshed_group = gl.groups.get(group_for_function.id)
+        refreshed_subgroup = gl.groups.get(subgroup_for_function.id)
+
+        root_shared_with = {
+            entry["group_full_path"]: entry["group_access_level"] for entry in refreshed_group.shared_with_groups
+        }
+        subgroup_shared_with = {
+            entry["group_full_path"]: entry["group_access_level"] for entry in refreshed_subgroup.shared_with_groups
+        }
+
+        assert root_shared_with == {
+            shared_group_for_function.full_path: AccessLevel.DEVELOPER.value,
+        }
+        assert shared_group_for_function.full_path not in subgroup_shared_with
+
+    def test__group_member_groups_allow_explicit_deeper_override(
+        self,
+        gl,
+        group_for_function,
+        subgroup_for_function,
+        nested_subgroup_for_function,
+        shared_group_for_function,
+    ):
+        config = f"""
+        projects_and_groups:
+          {group_for_function.full_path}/*:
+            group_members:
+              groups:
+                {shared_group_for_function.full_path}:
+                  group_access: {AccessLevel.DEVELOPER.value}
+          {nested_subgroup_for_function.full_path}/*:
+            group_members:
+              groups:
+                {shared_group_for_function.full_path}:
+                  group_access: {AccessLevel.MAINTAINER.value}
+        """
+
+        run_gitlabform(config, group_for_function.full_path)
+
+        refreshed_group = gl.groups.get(group_for_function.id)
+        refreshed_subgroup = gl.groups.get(subgroup_for_function.id)
+        refreshed_nested_subgroup = gl.groups.get(nested_subgroup_for_function.id)
+
+        root_shared_with = {
+            entry["group_full_path"]: entry["group_access_level"] for entry in refreshed_group.shared_with_groups
+        }
+        subgroup_shared_with = {
+            entry["group_full_path"]: entry["group_access_level"] for entry in refreshed_subgroup.shared_with_groups
+        }
+        nested_subgroup_shared_with = {
+            entry["group_full_path"]: entry["group_access_level"]
+            for entry in refreshed_nested_subgroup.shared_with_groups
+        }
+
+        assert root_shared_with == {
+            shared_group_for_function.full_path: AccessLevel.DEVELOPER.value,
+        }
+        assert shared_group_for_function.full_path not in subgroup_shared_with
+        assert nested_subgroup_shared_with == {
+            shared_group_for_function.full_path: AccessLevel.MAINTAINER.value,
+        }

--- a/tests/unit/configuration/test_group_section_locality.py
+++ b/tests/unit/configuration/test_group_section_locality.py
@@ -1,0 +1,18 @@
+from gitlabform.configuration import Configuration
+
+
+def test__has_group_section_defined_locally__returns_true_for_exact_subgroup_key():
+    configuration = Configuration(config_string="""
+        ---
+        projects_and_groups:
+          some_group/*:
+            group_members:
+              users: {}
+          some_group/subgroup/*:
+            group_settings:
+              visibility: private
+        """)
+
+    assert configuration.has_group_section_defined_locally("some_group", "group_members") is True
+    assert configuration.has_group_section_defined_locally("some_group/subgroup", "group_members") is False
+    assert configuration.has_group_section_defined_locally("some_group/subgroup", "group_settings") is True

--- a/tests/unit/processors/test_group_members_processor.py
+++ b/tests/unit/processors/test_group_members_processor.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock
+
+from gitlabform.processors.group.group_members_processor import GroupMembersProcessor
+
+
+class TestGroupMembersProcessor:
+    def setup_method(self):
+        self.gitlab = MagicMock()
+        self.configuration = MagicMock()
+        self.processor = GroupMembersProcessor(self.gitlab, self.configuration)
+
+    def test__can_proceed__skips_inherited_group_members_for_descendant_when_ancestor_is_processed(self):
+        self.configuration.has_group_section_defined_locally.return_value = False
+        self.processor.set_effective_groups(["some-group", "some-group/subgroup"])
+
+        assert self.processor._can_proceed("some-group/subgroup", {"group_members": {}}) is False
+
+    def test__can_proceed__allows_explicit_group_members_on_descendant(self):
+        self.configuration.has_group_section_defined_locally.return_value = True
+        self.processor.set_effective_groups(["some-group", "some-group/subgroup"])
+
+        assert self.processor._can_proceed("some-group/subgroup", {"group_members": {}}) is True
+
+    def test__can_proceed__allows_descendant_when_ancestor_is_not_in_current_run(self):
+        self.configuration.has_group_section_defined_locally.return_value = False
+        self.processor.set_effective_groups(["some-group/subgroup"])
+
+        assert self.processor._can_proceed("some-group/subgroup", {"group_members": {}}) is True


### PR DESCRIPTION
# What this changes
Following up on the discussion in PR #1301.

This fixes a `group_members` inheritance bug for subgroup processing.

When `group_members` was configured on a parent group like `group/*`, GitLabForm would merge that section into descendant subgroup effective config and then apply it as direct membership on each subgroup. That caused redundant direct user memberships and redundant direct group shares, even though GitLab already propagates access from parent groups to descendants.

With this change, GitLabForm now skips inherited-only `group_members` on descendant groups when the ancestor group is already part of the current run, while still allowing explicit deeper overrides.

# Why
GitLab already propagates group access down the subgroup tree, so GitLabForm should not re-apply the same `group_members` configuration as direct subgroup membership.

We still need to support cases like:

* `Group A/*` grants `Developer`
* `Group A/sub-group-b/sub-group-c/*` explicitly grants `Maintainer`

That deeper explicit override continues to work.

# Implementation summary

* Added config-level detection for whether a section is defined locally on a specific `group/*` key.
* Updated `GroupMembersProcessor` to skip inherited-only subgroup processing when an ancestor group is also being processed in the same run.
* Preserved explicit subgroup-level `group_members` overrides.
* Passed the effective group list into group processors so the processor can make that decision safely.