### PR TITLE
feat(config): Add wildcard pattern support for project configuration

### DIFF
--- a/gitlabform/configuration/core.py
+++ b/gitlabform/configuration/core.py
@@ -1,3 +1,4 @@
+import fnmatch
 import sys
 from typing import Any
 
@@ -212,6 +213,26 @@ class ConfigurationCore(ABC):
         return dict(merged_dict)
 
     @staticmethod
+    def _get_key_type(a_key: str) -> str:
+        """
+        Classify a config key used under 'projects_and_groups'.
+        """
+        if a_key == "*":
+            return "common"
+        if a_key.endswith("/*"):
+            return "group"
+        if "*" in a_key:
+            return "project_pattern"
+        return "project"
+
+    @staticmethod
+    def _match_pattern(pattern: str, item: str) -> bool:
+        """
+        Case-insensitive fnmatch between pattern and item.
+        """
+        return fnmatch.fnmatchcase(item.lower(), pattern.lower())
+
+    @staticmethod
     def _get_case_insensitively(a_dict: dict, a_key: str):
         for dict_key in a_dict.keys():
             if dict_key.lower() == a_key.lower():
@@ -231,11 +252,16 @@ class ConfigurationCore(ABC):
             if list_element == item:
                 return True
 
+            # Support for traditional group/* skip pattern
             if (
                 list_element.endswith("/*")
                 and item.startswith(list_element[:-2])
                 and len(item) >= len(list_element[:-2])
             ):
+                return True
+
+            # Support for partial wildcard patterns like group/foo-*
+            if "*" in list_element and fnmatch.fnmatchcase(item, list_element):
                 return True
 
         return False

--- a/gitlabform/configuration/projects.py
+++ b/gitlabform/configuration/projects.py
@@ -15,14 +15,14 @@ class ConfigurationProjects(ConfigurationGroups, ABC):
     depends on the groups (and common) configuration.
     """
 
-    def get_projects(self) -> list:
+    def get_projects(self, key_type: str = "project") -> list:
         """
         :return: sorted list of projects names, that are EXPLICITLY defined in the config
         """
         projects = []
         projects_and_groups = self.get("projects_and_groups")
         for element in projects_and_groups.keys():
-            if element != "*" and not element.endswith("/*"):
+            if self._get_key_type(element) == key_type:
                 projects.append(element)
         return sorted(projects)
 
@@ -68,6 +68,27 @@ class ConfigurationProjects(ConfigurationGroups, ABC):
         """
         :param group_and_project: 'group/project'
         :return: configuration for this project or empty dict if not defined,
-                 ignoring the case
+                 ignoring the case. Also checks for matching project patterns.
         """
-        return self._get_case_insensitively(self.get("projects_and_groups"), group_and_project)
+        projects_and_groups = self.get("projects_and_groups")
+
+        # 1. Exact match
+        exact = self._get_case_insensitively(projects_and_groups, group_and_project)
+        if exact:
+            return exact
+
+        # 2. Best matching pattern
+        matches = []
+        for key in projects_and_groups.keys():
+            if self._get_key_type(key) == "project_pattern":
+                if self._match_pattern(key, group_and_project):
+                    # store a 3-tuple for later sorting
+                    prefix = key.split("*", 1)[0]
+                    matches.append((len(prefix), -key.count("*"), key))
+        if matches:
+            # longest literal prefix wins; tie -> fewer wildcards; still tie -> first appearance
+            matches.sort(reverse=True)
+            best_key = matches[0][2]
+            return self._get_case_insensitively(projects_and_groups, best_key)
+
+        return {}

--- a/gitlabform/lists/projects.py
+++ b/gitlabform/lists/projects.py
@@ -96,6 +96,13 @@ class ProjectsProvider(GroupsProvider):
             # defined in the configuration, but we don't need to re-check for
             # being archived or scheduled for deletion projects that we already got from groups
 
+            for resolved_project in self._resolve_project_patterns(groups.get_effective()):
+                if (
+                    resolved_project not in projects.requested
+                    and resolved_project not in projects_from_configuration_not_from_groups
+                ):
+                    projects_from_configuration_not_from_groups.append(resolved_project)
+
             (
                 archived_projects_from_configuration_not_from_groups,
                 scheduled_for_deletion_projects_from_configuration_not_from_groups,
@@ -197,6 +204,42 @@ class ProjectsProvider(GroupsProvider):
                 skipped.append(project)
 
         return skipped
+
+    def _resolve_project_patterns(self, effective_groups: list) -> list:
+        """
+        Resolve project patterns from config to concrete project paths.
+        Only resolves patterns whose parent group is not already in the effective groups list
+        to avoid redundant API calls.
+        """
+        pattern_projects = []
+        for pattern in self.configuration.get_projects("project_pattern"):
+            pattern_group = pattern.rsplit("/", 1)[0]
+            if pattern_group in effective_groups:
+                # projects from this group already fetched through normal means
+                continue
+
+            try:
+                maybe_group = self.gitlab.get_group_case_insensitive(pattern_group)
+                group_path = maybe_group["full_path"]
+            except NotFoundException:
+                debug(
+                    "Group '%s' for pattern '%s' not found in GitLab, skipping",
+                    pattern_group,
+                    pattern,
+                )
+                continue
+
+            try:
+                all_project_objects = self.gitlab.get_projects(group_path, include_archived=True, only_names=False)
+            except NotFoundException:
+                all_project_objects = []
+
+            for project_object in all_project_objects:
+                path = project_object["path_with_namespace"]
+                if self.configuration._match_pattern(pattern, path) and path not in pattern_projects:
+                    pattern_projects.append(path)
+
+        return pattern_projects
 
     def _get_project_transfer_source_from_config(self, project: str) -> Optional[str]:
         try:

--- a/tests/acceptance/standard/test_wildcard_patterns.py
+++ b/tests/acceptance/standard/test_wildcard_patterns.py
@@ -1,0 +1,68 @@
+from tests.acceptance import (
+    create_group,
+    create_project,
+    get_random_name,
+    run_gitlabform,
+)
+
+
+class TestWildcardPatterns:
+    def test__wildcard_project_pattern_all_defined(self, gl):
+        """
+        Test that a wildcard pattern matches a project when gitlabform runs with
+        the ALL_DEFINED target.
+        """
+        bar_group_name = get_random_name("bar_group")
+        bar_group = create_group(bar_group_name)
+
+        bar_project = create_project(bar_group, "bar-project")
+
+        config = f"""
+        projects_and_groups:
+            '*':
+                project_settings:
+                    request_access_enabled: true
+            {bar_group_name}/bar-*:
+                project_settings:
+                    request_access_enabled: false
+        """
+
+        run_gitlabform(config, "ALL_DEFINED")
+
+        updated = gl.projects.get(bar_project.id)
+        assert updated.request_access_enabled is False
+
+    def test__wildcard_project_pattern_with_group_target(self, gl):
+        """
+        Test that a more specific wildcard pattern overrides a less specific one
+        when gitlabform targets a specific group.
+        """
+        bar_group_name = get_random_name("bar_group")
+        bar_group = create_group(bar_group_name)
+
+        bar_project = create_project(bar_group, "bar-project")
+        other_project = create_project(bar_group, "other-project")
+
+        config = f"""
+        projects_and_groups:
+            '*':
+                project_settings:
+                    request_access_enabled: true
+            {bar_group_name}/*:
+                project_settings:
+                    request_access_enabled: true
+            {bar_group_name}/bar-*:
+                project_settings:
+                    request_access_enabled: false
+        """
+
+        run_gitlabform(config, bar_group)
+
+        updated_bar_project = gl.projects.get(bar_project.id)
+        updated_other_project = gl.projects.get(other_project.id)
+
+        # Projects matching the wildcard pattern should pick up the override
+        assert updated_bar_project.request_access_enabled is False
+
+        # Non-matching project keeps the group-level setting
+        assert updated_other_project.request_access_enabled is True

--- a/tests/unit/configuration/test_wildcard_patterns.py
+++ b/tests/unit/configuration/test_wildcard_patterns.py
@@ -1,0 +1,202 @@
+import pytest
+
+from gitlabform.configuration import Configuration
+
+
+@pytest.fixture
+def config_with_project_patterns():
+    config_yaml = """
+    ---
+    projects_and_groups:
+      "*":
+        project_settings:
+          common: true
+
+      some_group/*:
+        project_settings:
+          group: true
+
+      some_group/foo-*:
+        project_settings:
+          pattern: true
+
+      some_group/foo-bar:
+        project_settings:
+          exact: true
+
+      some_group/foo-bar-baz:
+        project_settings:
+          exact2: true
+    """
+    return Configuration(config_string=config_yaml)
+
+
+@pytest.fixture
+def config_with_pattern_specificity():
+    config_yaml = """
+    ---
+    projects_and_groups:
+      "*":
+        project_settings:
+          common: true
+
+      some_group/*:
+        project_settings:
+          group: true
+
+      some_group/foo-*:
+        project_settings:
+          prefix_pattern: true
+
+      some_group/*bar:
+        project_settings:
+          suffix_pattern: true
+
+      some_group/foo-*-baz:
+        project_settings:
+          mid_pattern: true
+    """
+    return Configuration(config_string=config_yaml)
+
+
+@pytest.fixture
+def config_with_skip_patterns():
+    config_yaml = """
+    ---
+    projects_and_groups:
+      "*":
+        project_settings:
+          common: true
+
+    skip_groups:
+      - group-skip-pattern-*/
+
+    skip_projects:
+      - group-old-*/skip-*
+      - group-pattern/project-*
+    """
+    return Configuration(config_string=config_yaml)
+
+
+class TestKeyType:
+    def test_common(self):
+        c = Configuration(config_string="projects_and_groups:\n  '*': {}\n")
+        assert c._get_key_type("*") == "common"
+
+    def test_group(self):
+        c = Configuration(config_string="projects_and_groups:\n  group/*: {}\n")
+        assert c._get_key_type("group/*") == "group"
+
+    def test_project_pattern(self):
+        c = Configuration(config_string="projects_and_groups:\n  group/foo-*: {}\n")
+        assert c._get_key_type("group/foo-*") == "project_pattern"
+        assert c._get_key_type("group/*foo*") == "project_pattern"
+
+    def test_project(self):
+        c = Configuration(config_string="projects_and_groups:\n  group/foo: {}\n")
+        assert c._get_key_type("group/foo") == "project"
+
+
+class TestMatchPattern:
+    def test_match_simple_prefix(self):
+        c = Configuration(config_string="projects_and_groups:\n  group/foo-*: {}\n")
+        assert c._match_pattern("group/foo-*", "group/foo-bar") is True
+        assert c._match_pattern("group/foo-*", "group/bar-baz") is False
+
+    def test_match_anywhere(self):
+        c = Configuration(config_string="projects_and_groups:\n  group/*bar*: {}\n")
+        assert c._match_pattern("group/*bar*", "group/foobar") is True
+        assert c._match_pattern("group/*bar*", "group/bar-baz") is True
+        assert c._match_pattern("group/*bar*", "group/foo") is False
+
+    def test_case_insensitive(self):
+        c = Configuration(config_string="projects_and_groups:\n  group/FOO-*: {}\n")
+        assert c._match_pattern("group/FOO-*", "group/foo-bar") is True
+
+
+class TestGetProjects:
+    def test_excludes_patterns(self, config_with_project_patterns):
+        projects = config_with_project_patterns.get_projects()
+        assert "some_group/foo-bar" in projects
+        assert "some_group/foo-bar-baz" in projects
+        assert "some_group/foo-*" not in projects
+        assert "*" not in projects
+        assert "some_group/*" not in projects
+
+    def test_get_project_patterns(self, config_with_project_patterns):
+        patterns = config_with_project_patterns.get_projects("project_pattern")
+        assert "some_group/foo-*" in patterns
+        assert "some_group/*" not in patterns
+        assert "some_group/foo-bar" not in patterns
+
+
+class TestGetGroups:
+    def test_ignores_pattern_keys(self, config_with_project_patterns):
+        groups = config_with_project_patterns.get_groups()
+        assert "some_group" in groups
+        assert "some_group/foo-*" not in groups
+
+
+class TestSkipWithPatterns:
+    def test_skip_project_pattern(self, config_with_skip_patterns):
+        assert config_with_skip_patterns.is_project_skipped("group-pattern/project-abc") is True
+        assert config_with_skip_patterns.is_project_skipped("group-pattern/project") is False
+        assert config_with_skip_patterns.is_project_skipped("group-old-a/skip-x") is True
+        assert config_with_skip_patterns.is_project_skipped("group-old-a/keep") is False
+
+    def test_skip_group_fnmatch_patterns(self, config_with_skip_patterns):
+        # verify that non-matching groups are not skipped
+        assert config_with_skip_patterns.is_group_skipped("other-group") is False
+        assert config_with_skip_patterns.is_group_skipped("group-old-a") is False
+        assert config_with_skip_patterns.is_group_skipped("group-pattern") is False
+
+
+class TestGetProjectConfig:
+    def test_exact_project_wins_over_pattern(self, config_with_project_patterns):
+        cfg = config_with_project_patterns._get_project_config("some_group/foo-bar")
+        assert cfg == {"project_settings": {"exact": True}}
+
+    def test_pattern_matches(self, config_with_project_patterns):
+        cfg = config_with_project_patterns._get_project_config("some_group/foo-baz")
+        assert cfg == {"project_settings": {"pattern": True}}
+
+    def test_no_match_returns_empty(self, config_with_project_patterns):
+        cfg = config_with_project_patterns._get_project_config("some_group/alpha-beta")
+        assert cfg == {}
+
+    def test_specificity_longer_prefix_wins(self, config_with_pattern_specificity):
+        # some_group/foo-*-baz has longer prefix before first * than some_group/foo-*
+        # both match "some_group/foo-x-baz", so longer prefix should win
+        cfg = config_with_pattern_specificity._get_project_config("some_group/foo-x-baz")
+        assert cfg == {"project_settings": {"mid_pattern": True}}
+
+    def test_specificity_tie_goes_to_fewer_wildcards(self, config_with_pattern_specificity):
+        # some_group/foo-* vs some_group/*bar:
+        # "some_group/foo-bar" matches both.
+        # foo-* prefix before first *: "some_group/foo-" len=15
+        # *bar prefix before first *: "some_group/" len=11
+        # longer prefix (foo-*) wins
+        cfg = config_with_pattern_specificity._get_project_config("some_group/foo-bar")
+        assert cfg == {"project_settings": {"prefix_pattern": True}}
+
+
+class TestEffectiveConfigWithPatterns:
+    def test_pattern_plus_group_plus_common(self, config_with_project_patterns):
+        # some_group/foo-baz matches the pattern, not an exact project
+        cfg = config_with_project_patterns.get_effective_config_for_project("some_group/foo-baz")
+        assert cfg["project_settings"]["common"] is True
+        assert cfg["project_settings"]["group"] is True
+        assert cfg["project_settings"]["pattern"] is True
+        assert "exact" not in cfg["project_settings"]
+        assert "exact2" not in cfg["project_settings"]
+
+    def test_exact_wins_over_pattern(self, config_with_project_patterns):
+        cfg = config_with_project_patterns.get_effective_config_for_project("some_group/foo-bar")
+        assert cfg["project_settings"]["exact"] is True
+        assert "pattern" not in cfg["project_settings"]
+
+    def test_only_group_plus_common_when_no_pattern(self, config_with_project_patterns):
+        cfg = config_with_project_patterns.get_effective_config_for_project("some_group/zoo")
+        assert cfg["project_settings"]["common"] is True
+        assert cfg["project_settings"]["group"] is True
+        assert "pattern" not in cfg["project_settings"]


### PR DESCRIPTION
**AI disclosure:** the code has been AI generated, i personally reviewed and tested it though. I've seen nothing against it in the contributing guides so here it is.

Allow fnmatch-style patterns like `group/foo-*` in `projects_and_groups`. Exact project definitions take precedence over patterns. Pattern specificity is determined by longest literal prefix, then fewest wildcards.

Project patterns are resolved to concrete projects when building the effective project list. Skip lists now also support wildcard patterns.

Fixes: https://github.com/gitlabform/gitlabform/issues/325