### PR TITLE
ci: consume package artifact from main workflow in pypi release

### DIFF
--- a/.github/workflows/_releases.yml
+++ b/.github/workflows/_releases.yml
@@ -137,7 +137,7 @@ jobs:
           path: dist
       - name: Publish to PyPI
         run: |
-          uv run --no-sync release pypi --publish-url https://test.pypi.org/legacy/
+          uv run --no-sync release pypi
 
   publish-to-ghcr:
     name: Publish GHCR

--- a/.github/workflows/_releases.yml
+++ b/.github/workflows/_releases.yml
@@ -64,17 +64,6 @@ jobs:
           MANUAL_UPSTREAM_RUN_ID: ${{ inputs.override_run_id }}
         run: uv run release gh-workflow-check
 
-  # TODO: Remove this job when all the release jobs have been migrated
-  # to consume build artifacts from Main workflow instead of rebuilding.
-  build-release-artifacts:
-    name: Build release artifacts
-    if: ${{ needs.prep-release.outputs.is_valid_release == 'true' }}
-    needs:
-      - prep-release
-    uses: ./.github/workflows/build.yml
-    with:
-      BRANCH_REF: ${{ needs.prep-release.outputs.semver_tag }}
-
   publish-docs:
     name: Publish Docs
     if: ${{ needs.prep-release.outputs.is_valid_release == 'true' }}
@@ -120,7 +109,6 @@ jobs:
     if: ${{ needs.prep-release.outputs.is_valid_release == 'true' }}
     needs:
       - prep-release
-      - build-release-artifacts
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -140,12 +128,13 @@ jobs:
       - name: Setup Python ${{ env.UV_PYTHON }} and install dependencies
         run: |
           uv sync --frozen --no-dev --group release
-      # TODO: In a separate PR, consume the build artifact (package-dist) uploaded
-      # in build-release-artifacts instead of rebuilding and verifying the package here.
-      - name: Build and verify the package
-        run: |
-          uv run --no-sync package build
-          uv run --no-sync package verify
+      - name: Download built package
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ needs.prep-release.outputs.target_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: package-dist
+          path: dist
       - name: Publish to PyPI
         run: |
           uv run --no-sync release pypi
@@ -155,7 +144,6 @@ jobs:
     if: ${{ needs.prep-release.outputs.is_valid_release == 'true' }}
     needs:
       - prep-release
-      - build-release-artifacts
       - publish-to-pypi
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/_releases.yml
+++ b/.github/workflows/_releases.yml
@@ -137,7 +137,7 @@ jobs:
           path: dist
       - name: Publish to PyPI
         run: |
-          uv run --no-sync release pypi
+          uv run --no-sync release pypi --publish-url https://test.pypi.org/legacy/
 
   publish-to-ghcr:
     name: Publish GHCR

--- a/.github/workflows/_releases.yml
+++ b/.github/workflows/_releases.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           uv sync --frozen --no-dev --group release
       - name: Download built package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           run-id: ${{ needs.prep-release.outputs.target_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Motivation**
Currently, the `_releases.yml` workflow performs a full redundant package build and verification step for the PyPI release. This goes against the "Build Once, Deploy Anywhere" principle, adds unnecessary execution time, and introduces a risk of discrepancy between the artifacts verified in CI and the artifacts actually published to PyPI. 

**Changes**
* Removed the redundant `build-release-artifacts` job entirely.
* Refactored the `publish-to-pypi` job to download the verified `package-dist` artifact directly from the upstream `_main.yml` run via the `actions/download-artifact` action instead of rebuilding from source.
* Preserved the `checkout` and `setup-uv-local` steps in the PyPI job, as they are required to satisfy the `release pypi` custom publisher script.
* Removed `build-release-artifacts` from the `needs` list of the `publish-to-ghcr` job because the docker build currently builds from the source. This will be updated in a follow up PR.

**Testing**
* Successfully tested the end-to-end OIDC Trusted Publishing flow against [TestPyPI](https://test.pypi.org/project/gitlabform/) via my [repository fork](https://github.com/amimas/gitlabform/actions/runs/27997161417/job/82862123504). Note that in my forked repo, I haven't setup credentials or destination for container publish testing.

