### PR TITLE
fix(group_saml_links): stop delete-and-recreate churn on unchanged links

### DIFF
--- a/gitlabform/processors/group/group_saml_links_processor.py
+++ b/gitlabform/processors/group/group_saml_links_processor.py
@@ -29,7 +29,13 @@ class GroupSAMLLinksProcessor(AbstractProcessor):
 
             if existing_link is None:
                 group.saml_group_links.create(link_configuration)
-            elif self._link_differs(existing_link, link_configuration):
+                continue
+
+            # GitLab API uses 'name' where the config uses 'saml_group_name'.
+            expected = {**link_configuration, "name": saml_group_name}
+            expected.pop("saml_group_name", None)
+
+            if self._needs_update(existing_link.asdict(), expected):
                 # GitLab API has no update endpoint for SAML links; delete and recreate instead.
                 debug(f"Updating SAML link: {saml_group_name} with {link_configuration}")
                 existing_link.delete()
@@ -37,15 +43,6 @@ class GroupSAMLLinksProcessor(AbstractProcessor):
 
         if enforce_links:
             self._delete_extra_links(group, existing_links, configured_links)
-
-    def _link_differs(self, existing: GroupSAMLGroupLink, configured: dict) -> bool:
-        # 'saml_group_name' was already used to look up the existing link, so the names match.
-        for key, value in configured.items():
-            if key == "saml_group_name":
-                continue
-            if getattr(existing, key, None) != value:
-                return True
-        return False
 
     def _delete_extra_links(
         self,

--- a/gitlabform/processors/group/group_saml_links_processor.py
+++ b/gitlabform/processors/group/group_saml_links_processor.py
@@ -31,7 +31,9 @@ class GroupSAMLLinksProcessor(AbstractProcessor):
                 group.saml_group_links.create(link_configuration)
                 continue
 
-            # GitLab API uses 'name' where the config uses 'saml_group_name'.
+            # GitLab API's request and response attributes differs when SAML link is created vs retrieved.
+            # On creation or retrieving a link, attribute is called `saml_group_name` but and returned response is 'name' instead.
+            # To compare existing link (retrieved from GitLab) with configured link, link configuration need to replace `saml_group_name` with `name`
             expected = {**link_configuration, "name": saml_group_name}
             expected.pop("saml_group_name", None)
 

--- a/gitlabform/processors/group/group_saml_links_processor.py
+++ b/gitlabform/processors/group/group_saml_links_processor.py
@@ -11,42 +11,41 @@ class GroupSAMLLinksProcessor(AbstractProcessor):
     def __init__(self, gitlab: GitLab):
         super().__init__("group_saml_links", gitlab)
 
-    def _process_configuration(self, group_path: str, configuration: dict) -> None:
+    def _process_configuration(self, group_path_and_name: str, configuration: dict) -> None:
         """Process the SAML links configuration for a group."""
 
-        configured_links = configuration.get("group_saml_links", {})
+        configured_section = configuration.get("group_saml_links", {}) or {}
         enforce_links = configuration.get("group_saml_links|enforce", False)
 
-        group: Group = self.gl.get_group_by_path_cached(group_path)
+        configured_links = {k: v for k, v in configured_section.items() if k != "enforce"}
+
+        group: Group = self.gl.get_group_by_path_cached(group_path_and_name)
         existing_links: List[GroupSAMLGroupLink] = group.saml_group_links.list(get_all=True)
-        existing_link_names = [existing_link.name for existing_link in existing_links]
+        existing_by_name = {link.name: link for link in existing_links}
 
-        # Remove 'enforce' key from the config so that it's not treated as a "link"
-        if enforce_links:
-            configured_links.pop("enforce")
-
-        # Process each configured SAML link
         for _, link_configuration in configured_links.items():
             saml_group_name = link_configuration.get("saml_group_name")
+            existing_link = existing_by_name.get(saml_group_name)
 
-            if saml_group_name not in existing_link_names:
-                # Create the saml link as it does not already exist
+            if existing_link is None:
                 group.saml_group_links.create(link_configuration)
-                group.save()
-            else:
-                # Check if the existing link needs to be updated
-                # GitLab API does not provide an endpoint for updating SAML links
-                # If update required, we need to delete and recreate
-                existing_link_config = next((link for link in existing_links if link.name == saml_group_name), None)
-                if existing_link_config and self._needs_update(existing_link_config.asdict(), link_configuration):
-                    debug(f"Updating SAML link: {saml_group_name} with {link_configuration}")
-                    existing_link_config.delete()
-                    group.saml_group_links.create(link_configuration)
-                    group.save()
+            elif self._link_differs(existing_link, link_configuration):
+                # GitLab API has no update endpoint for SAML links; delete and recreate instead.
+                debug(f"Updating SAML link: {saml_group_name} with {link_configuration}")
+                existing_link.delete()
+                group.saml_group_links.create(link_configuration)
 
-        # Process enforce mode
         if enforce_links:
             self._delete_extra_links(group, existing_links, configured_links)
+
+    def _link_differs(self, existing: GroupSAMLGroupLink, configured: dict) -> bool:
+        # 'saml_group_name' was already used to look up the existing link, so the names match.
+        for key, value in configured.items():
+            if key == "saml_group_name":
+                continue
+            if getattr(existing, key, None) != value:
+                return True
+        return False
 
     def _delete_extra_links(
         self,
@@ -55,9 +54,7 @@ class GroupSAMLLinksProcessor(AbstractProcessor):
         configured: dict,
     ) -> None:
         """Delete any SAML links that are not in the configuration."""
-        known_names = [
-            common_name["saml_group_name"] for common_name in configured.values() if common_name != "enforce"
-        ]
+        known_names = {link["saml_group_name"] for link in configured.values()}
 
         for link in existing:
             if link.name not in known_names:

--- a/tests/acceptance/premium/test_group_saml_links.py
+++ b/tests/acceptance/premium/test_group_saml_links.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from tests.acceptance import run_gitlabform
@@ -45,6 +47,36 @@ class TestGroupSamlLinks:
         assert len(saml_links) == 1
         assert saml_links[0].name == "devops_users"
         assert saml_links[0].access_level == AccessLevel.get_value("developer")
+
+    def test__no_churn_when_config_unchanged(self, gl, group_for_function, caplog):
+        assert len(group_for_function.saml_group_links.list()) == 0, "group_saml_links is not empty"
+
+        config = f"""
+        projects_and_groups:
+          {group_for_function.full_path}/*:
+             group_saml_links:
+               devops_users:
+                 saml_group_name: devops_users
+                 access_level: maintainer
+        """
+
+        # First run creates the link.
+        run_gitlabform(config, group_for_function)
+        assert len(gl.groups.get(group_for_function.id).saml_group_links.list(get_all=True)) == 1
+
+        # Second run with the same config must not trigger a delete + recreate.
+        caplog.clear()
+        with caplog.at_level(logging.DEBUG):
+            run_gitlabform(config, group_for_function)
+
+        assert (
+            "Updating SAML link" not in caplog.text
+        ), f"Expected no SAML link updates on second run, got: {caplog.text}"
+
+        saml_links = gl.groups.get(group_for_function.id).saml_group_links.list(get_all=True)
+        assert len(saml_links) == 1
+        assert saml_links[0].name == "devops_users"
+        assert saml_links[0].access_level == AccessLevel.get_value("maintainer")
 
     def test__enforce_saml_links(self, gl, group_for_function):
 

--- a/tests/unit/processors/test_group_saml_links_processor.py
+++ b/tests/unit/processors/test_group_saml_links_processor.py
@@ -16,6 +16,7 @@ class TestGroupSAMLLinksProcessor:
         link = MagicMock()
         link.name = name
         link.access_level = access_level
+        link.asdict.return_value = {"name": name, "access_level": access_level}
         return link
 
     def _group_with_links(self, *links: MagicMock) -> MagicMock:

--- a/tests/unit/processors/test_group_saml_links_processor.py
+++ b/tests/unit/processors/test_group_saml_links_processor.py
@@ -1,0 +1,92 @@
+from unittest.mock import MagicMock, patch
+
+from gitlabform.processors.group.group_saml_links_processor import GroupSAMLLinksProcessor
+from gitlabform.processors.util.decorators import SafeDict
+
+
+class TestGroupSAMLLinksProcessor:
+    def setup_method(self):
+        self.gitlab = MagicMock()
+        with patch("gitlabform.processors.abstract_processor.GitlabWrapper"):
+            self.processor = GroupSAMLLinksProcessor(self.gitlab)
+        self.processor.gl = MagicMock()
+
+    @staticmethod
+    def _saml_link(name: str, access_level: int) -> MagicMock:
+        link = MagicMock()
+        link.name = name
+        link.access_level = access_level
+        return link
+
+    def _group_with_links(self, *links: MagicMock) -> MagicMock:
+        group = MagicMock()
+        group.saml_group_links.list.return_value = list(links)
+        self.processor.gl.get_group_by_path_cached.return_value = group
+        return group
+
+    def test_no_churn_when_configured_link_matches_existing(self):
+        existing = self._saml_link("gitlab-test-maintainer", 40)
+        group = self._group_with_links(existing)
+
+        configuration = SafeDict(
+            {
+                "group_saml_links": {
+                    "maintainers": {
+                        "saml_group_name": "gitlab-test-maintainer",
+                        "access_level": 40,
+                    },
+                }
+            }
+        )
+
+        self.processor._process_configuration("test/group", configuration)
+
+        group.saml_group_links.create.assert_not_called()
+        existing.delete.assert_not_called()
+        group.saml_group_links.delete.assert_not_called()
+
+    def test_creates_link_when_missing(self):
+        group = self._group_with_links()
+
+        link_config = {"saml_group_name": "gitlab-test-developer", "access_level": 30}
+        configuration = SafeDict({"group_saml_links": {"developers": link_config}})
+
+        self.processor._process_configuration("test/group", configuration)
+
+        group.saml_group_links.create.assert_called_once_with(link_config)
+
+    def test_recreates_link_when_access_level_changes(self):
+        existing = self._saml_link("gitlab-test-developer", 30)
+        group = self._group_with_links(existing)
+
+        link_config = {"saml_group_name": "gitlab-test-developer", "access_level": 40}
+        configuration = SafeDict({"group_saml_links": {"developers": link_config}})
+
+        self.processor._process_configuration("test/group", configuration)
+
+        existing.delete.assert_called_once()
+        group.saml_group_links.create.assert_called_once_with(link_config)
+
+    def test_enforce_deletes_unconfigured_links(self):
+        kept = self._saml_link("gitlab-test-maintainer", 40)
+        stray = self._saml_link("gitlab-stray", 20)
+        group = self._group_with_links(kept, stray)
+
+        configuration = SafeDict(
+            {
+                "group_saml_links": {
+                    "enforce": True,
+                    "maintainers": {
+                        "saml_group_name": "gitlab-test-maintainer",
+                        "access_level": 40,
+                    },
+                }
+            }
+        )
+
+        self.processor._process_configuration("test/group", configuration)
+
+        group.saml_group_links.delete.assert_called_once_with("gitlab-stray")
+        # the matching link must not churn
+        kept.delete.assert_not_called()
+        group.saml_group_links.create.assert_not_called()


### PR DESCRIPTION
The processor compared the configured field `saml_group_name` against the GitLab API field `name` via the generic `_needs_update` helper.

Because `saml_group_name` was always "only in configuration", the helper returned True on every run, deleting and recreating each link.

Compare via the API field instead, drop the misplaced `group.save()` calls, and filter the `enforce` control flag out before iterating so it cannot be processed as a link.

Fixes #1328