### PR TITLE
fix(ci): restore fork PR workflows broken by actions/checkout v7

### DIFF
--- a/.github/workflows/pr-ci-workflow.yml
+++ b/.github/workflows/pr-ci-workflow.yml
@@ -1,12 +1,5 @@
 name: "CI - Build · Lint · Tests"
 
-# Reusable workflow containing the actual CI jobs for pull request validation.
-# This file is called by prs-entrypoint.yml and is intentionally separated so that
-# event/routing logic stays in the entrypoint while the CI job set remains reusable.
-
-# This reusable workflow does not receive secrets automatically from the PR event.
-# The caller workflow (prs-entrypoint.yml) must explicitly pass secrets when calling it.
-
 on:
   workflow_call:
     inputs:
@@ -33,14 +26,6 @@ jobs:
     uses: ./.github/workflows/tests-unit.yml
     with:
       BRANCH_REF: ${{ inputs.BRANCH_REF }}
-    secrets: inherit
-
-  tests-acceptance:
-    name: Acceptance Tests
-    uses: ./.github/workflows/tests-acceptance.yml
-    with:
-      BRANCH_REF: ${{ inputs.BRANCH_REF }}
-      environment: Integrate Pull Request
     secrets: inherit
 
   analyze:
@@ -92,7 +77,6 @@ jobs:
     # - name: Setup runtime (example)
     #   uses: actions/setup-example@v1
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:
@@ -104,23 +88,6 @@ jobs:
 
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/prs-entrypoint-forks.yml
+++ b/.github/workflows/prs-entrypoint-forks.yml
@@ -1,13 +1,8 @@
-name: "CI - Fork PRs"
-
-# This workflow handles pull requests from forked repositories.
-# It uses pull_request_target so the reusable CI workflow can receive explicit secrets.
+name: "CI - Acceptance Tests"
 
 permissions:
   actions: read
   contents: read
-  pull-requests: write
-  security-events: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -18,17 +13,14 @@ on:
       - main
 
 jobs:
-  pr_jobs:
-    name: "Pipeline"
-    # github.event.pull_request object defined here: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2026-03-10#get-a-pull-request
-    if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-    uses: ./.github/workflows/pr-ci-workflow.yml
+  tests-acceptance:
+    name: "Acceptance Tests"
+    uses: ./.github/workflows/tests-acceptance.yml
     permissions:
       actions: read
       contents: read
       packages: read
-      pull-requests: write
-      security-events: write
     with:
       BRANCH_REF: ${{ github.event.pull_request.head.sha }}
+      environment: Integrate Pull Request
     secrets: inherit

--- a/.github/workflows/prs-entrypoint-main.yml
+++ b/.github/workflows/prs-entrypoint-main.yml
@@ -1,13 +1,8 @@
 name: "CI - PRs"
 
-# This workflow is the entrypoint for pull requests opened from host repository.
-# Fork PRs are handled by prs-entrypoint-forks.yml using pull_request_target.
-# It forwards the branch SHA and explicit secrets to the reusable workflow.
-
 permissions:
   actions: read
   contents: read
-  pull-requests: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -20,14 +15,11 @@ on:
 jobs:
   pr_jobs:
     name: "Pipeline"
-    # github.event.pull_request object defined here: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2026-03-10#get-a-pull-request
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     uses: ./.github/workflows/pr-ci-workflow.yml
     permissions:
       actions: read
       contents: read
       packages: read
-      pull-requests: write
       security-events: write
     with:
       BRANCH_REF: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/tests-acceptance.yml
+++ b/.github/workflows/tests-acceptance.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           ref: ${{ inputs.BRANCH_REF }}
           fetch-depth: 2
+          allow-unsafe-pr-checkout: true
       - name: Configure uv environment
         uses: ./.github/actions/setup-uv-local
       - name: Install dependencies
@@ -69,6 +70,7 @@ jobs:
         with:
           ref: ${{ inputs.BRANCH_REF }}
           fetch-depth: 2
+          allow-unsafe-pr-checkout: true
       - name: Configure uv environment
         uses: ./.github/actions/setup-uv-local
       - name: Install dependencies

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -9,7 +9,7 @@ on:
         required: true
     secrets:
       CODECOV_TOKEN:
-        required: true
+        required: false
 
 permissions:
   contents: read
@@ -18,6 +18,8 @@ jobs:
   unit:
     name: "Unit (${{ matrix.python-version }})"
     runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -37,6 +39,7 @@ jobs:
       - name: Run unit tests
         run: uv run --no-sync qa test tests/unit --cov=. --cov-report=xml --log-cli-level=WARNING
       - name: Upload coverage to Codecov
+        if: ${{ env.CODECOV_TOKEN != '' }}
         uses: Wandalen/wretry.action@v3
         with:
           action: codecov/codecov-action@v3


### PR DESCRIPTION
Fix fork PR CI broken by actions/checkout v7 by splitting the triggers: pull_request for build/lint/unit/CodeQL, pull_request_target with allow-unsafe-pr-checkout for acceptance (licensed jobs remain gated by the "Integrate Pull Request" environment).