### PR TITLE
fix: format group member expiry dates

### DIFF
--- a/gitlabform/processors/group/group_members_processor.py
+++ b/gitlabform/processors/group/group_members_processor.py
@@ -6,6 +6,7 @@ from logging import info, critical, error
 from gitlabform.constants import EXIT_INVALID_INPUT
 from gitlabform.gitlab import GitLab, AccessLevel
 from gitlabform.processors.abstract_processor import AbstractProcessor
+from gitlabform.util import format_expires_at
 from gitlab.v4.objects import Group, GroupMember, User
 from gitlab import GitlabDeleteError, GitlabError, GitlabGetError
 
@@ -60,14 +61,6 @@ class GroupMembersProcessor(AbstractProcessor):
 
         return groups_to_set_by_group_path, users_to_set_by_username
 
-    @staticmethod
-    def _format_expires_at(expires_at):
-        if expires_at is None:
-            return None
-        if hasattr(expires_at, "strftime"):
-            return expires_at.strftime("%Y-%m-%d")
-        return expires_at
-
     def _process_groups(
         self,
         group_being_processed: Group,
@@ -84,9 +77,7 @@ class GroupMembersProcessor(AbstractProcessor):
         for share_with_group_path in groups_to_share_with_by_path:
             group_access_to_set = groups_to_share_with_by_path[share_with_group_path]["group_access"]
 
-            expires_at_to_set = self._format_expires_at(
-                groups_to_share_with_by_path[share_with_group_path].get("expires_at")
-            )
+            expires_at_to_set = format_expires_at(groups_to_share_with_by_path[share_with_group_path].get("expires_at"))
 
             if share_with_group_path in groups_before_by_group_path:
                 group_access_before = groups_before_by_group_path[share_with_group_path]["group_access_level"]
@@ -177,7 +168,7 @@ class GroupMembersProcessor(AbstractProcessor):
 
                 for user in users_to_set_with_this_level:
                     access_level_to_set = users_to_set_by_username[user]["access_level"]
-                    expires_at_to_set = self._format_expires_at(users_to_set_by_username[user].get("expires_at"))
+                    expires_at_to_set = format_expires_at(users_to_set_by_username[user].get("expires_at"))
 
                     member_role_id_or_name = (
                         users_to_set_by_username[user]["member_role"]

--- a/gitlabform/processors/group/group_members_processor.py
+++ b/gitlabform/processors/group/group_members_processor.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Dict, Tuple
 
-from logging import debug, info, critical, error
+from logging import info, critical, error
 
 from gitlabform.constants import EXIT_INVALID_INPUT
 from gitlabform.gitlab import GitLab, AccessLevel
@@ -60,6 +60,14 @@ class GroupMembersProcessor(AbstractProcessor):
 
         return groups_to_set_by_group_path, users_to_set_by_username
 
+    @staticmethod
+    def _format_expires_at(expires_at):
+        if expires_at is None:
+            return None
+        if hasattr(expires_at, "strftime"):
+            return expires_at.strftime("%Y-%m-%d")
+        return expires_at
+
     def _process_groups(
         self,
         group_being_processed: Group,
@@ -76,10 +84,8 @@ class GroupMembersProcessor(AbstractProcessor):
         for share_with_group_path in groups_to_share_with_by_path:
             group_access_to_set = groups_to_share_with_by_path[share_with_group_path]["group_access"]
 
-            expires_at_to_set = (
-                groups_to_share_with_by_path[share_with_group_path]["expires_at"]
-                if "expires_at" in groups_to_share_with_by_path[share_with_group_path]
-                else None
+            expires_at_to_set = self._format_expires_at(
+                groups_to_share_with_by_path[share_with_group_path].get("expires_at")
             )
 
             if share_with_group_path in groups_before_by_group_path:
@@ -171,11 +177,7 @@ class GroupMembersProcessor(AbstractProcessor):
 
                 for user in users_to_set_with_this_level:
                     access_level_to_set = users_to_set_by_username[user]["access_level"]
-                    expires_at_to_set = (
-                        users_to_set_by_username[user]["expires_at"]
-                        if "expires_at" in users_to_set_by_username[user]
-                        else None
-                    )
+                    expires_at_to_set = self._format_expires_at(users_to_set_by_username[user].get("expires_at"))
 
                     member_role_id_or_name = (
                         users_to_set_by_username[user]["member_role"]

--- a/gitlabform/processors/project/members_processor.py
+++ b/gitlabform/processors/project/members_processor.py
@@ -6,6 +6,7 @@ from gitlab.v4.objects import Project, User
 from gitlabform.constants import EXIT_INVALID_INPUT
 from gitlabform.gitlab import GitLab
 from gitlabform.processors.abstract_processor import AbstractProcessor
+from gitlabform.util import format_expires_at
 
 
 class MembersProcessor(AbstractProcessor):
@@ -39,7 +40,7 @@ class MembersProcessor(AbstractProcessor):
             current_groups = self.gitlab.get_groups_from_project(project_and_group)
             for group in groups:
                 info(f"Processing group {group}...")
-                expires_at = groups[group]["expires_at"].strftime("%Y-%m-%d") if "expires_at" in groups[group] else None
+                expires_at = format_expires_at(groups[group].get("expires_at"))
                 access_level = groups[group]["group_access"] if "group_access" in groups[group] else None
 
                 # we only add the group if it doesn't have the correct settings
@@ -97,7 +98,7 @@ class MembersProcessor(AbstractProcessor):
                     continue
                 user_id = gitlab_user.id
 
-                expires_at = users[user]["expires_at"].strftime("%Y-%m-%d") if "expires_at" in users[user] else None
+                expires_at = format_expires_at(users[user].get("expires_at"))
                 access_level = users[user]["access_level"] if "access_level" in users[user] else None
                 member_role_id_or_name = users[user]["member_role"] if "member_role" in users[user] else None
                 if member_role_id_or_name:

--- a/gitlabform/util.py
+++ b/gitlabform/util.py
@@ -1,7 +1,14 @@
 import json
+from datetime import date
 from io import StringIO
 
 from ruamel.yaml import YAML
+
+
+def format_expires_at(expires_at):
+    if isinstance(expires_at, date):
+        return expires_at.strftime("%Y-%m-%d")
+    return expires_at
 
 
 def to_str(a_dict: dict) -> str:

--- a/tests/unit/processors/test_group_members_processor.py
+++ b/tests/unit/processors/test_group_members_processor.py
@@ -1,0 +1,63 @@
+from datetime import date
+from unittest.mock import MagicMock
+
+from gitlabform.processors.group.group_members_processor import GroupMembersProcessor
+
+
+class TestGroupMembersProcessor:
+    def setup_method(self):
+        self.processor = GroupMembersProcessor.__new__(GroupMembersProcessor)
+        self.processor.gl = MagicMock()
+
+    def test__format_expires_at_converts_date_to_gitlab_string(self):
+        assert GroupMembersProcessor._format_expires_at(date(2026, 6, 18)) == "2026-06-18"
+
+    def test__format_expires_at_leaves_string_unchanged(self):
+        assert GroupMembersProcessor._format_expires_at("2026-06-18") == "2026-06-18"
+
+    def test__format_expires_at_leaves_none_unchanged(self):
+        assert GroupMembersProcessor._format_expires_at(None) is None
+
+    def test__process_groups_formats_date_expires_at_before_sharing(self):
+        group = MagicMock()
+        group.shared_with_groups = []
+        self.processor.gl.get_group_id.return_value = 123
+
+        self.processor._process_groups(
+            group,
+            {
+                "parent/child": {
+                    "group_access": 30,
+                    "expires_at": date(2026, 6, 18),
+                }
+            },
+            enforce_group_members=False,
+        )
+
+        group.share.assert_called_once_with(123, 30, "2026-06-18")
+
+    def test__process_users_formats_date_expires_at_before_creating_member(self):
+        group = MagicMock()
+        group.members.list.return_value = []
+        self.processor.gl.get_user_id_cached.return_value = 456
+
+        self.processor._process_users(
+            {
+                "Alice": {
+                    "access_level": 30,
+                    "expires_at": date(2026, 6, 18),
+                }
+            },
+            enforce_group_members=False,
+            keep_bots=False,
+            group=group,
+        )
+
+        group.members.create.assert_called_once_with(
+            {
+                "user_id": 456,
+                "access_level": 30,
+                "expires_at": "2026-06-18",
+                "member_role_id": None,
+            }
+        )

--- a/tests/unit/processors/test_group_members_processor.py
+++ b/tests/unit/processors/test_group_members_processor.py
@@ -2,22 +2,12 @@ from datetime import date
 from unittest.mock import MagicMock
 
 from gitlabform.processors.group.group_members_processor import GroupMembersProcessor
-from gitlabform.util import format_expires_at
 
 
 class TestGroupMembersProcessor:
     def setup_method(self):
         self.processor = GroupMembersProcessor.__new__(GroupMembersProcessor)
         self.processor.gl = MagicMock()
-
-    def test__format_expires_at_converts_date_to_gitlab_string(self):
-        assert format_expires_at(date(2026, 6, 18)) == "2026-06-18"
-
-    def test__format_expires_at_leaves_string_unchanged(self):
-        assert format_expires_at("2026-06-18") == "2026-06-18"
-
-    def test__format_expires_at_leaves_none_unchanged(self):
-        assert format_expires_at(None) is None
 
     def test__process_groups_formats_date_expires_at_before_sharing(self):
         group = MagicMock()

--- a/tests/unit/processors/test_group_members_processor.py
+++ b/tests/unit/processors/test_group_members_processor.py
@@ -2,6 +2,7 @@ from datetime import date
 from unittest.mock import MagicMock
 
 from gitlabform.processors.group.group_members_processor import GroupMembersProcessor
+from gitlabform.util import format_expires_at
 
 
 class TestGroupMembersProcessor:
@@ -10,13 +11,13 @@ class TestGroupMembersProcessor:
         self.processor.gl = MagicMock()
 
     def test__format_expires_at_converts_date_to_gitlab_string(self):
-        assert GroupMembersProcessor._format_expires_at(date(2026, 6, 18)) == "2026-06-18"
+        assert format_expires_at(date(2026, 6, 18)) == "2026-06-18"
 
     def test__format_expires_at_leaves_string_unchanged(self):
-        assert GroupMembersProcessor._format_expires_at("2026-06-18") == "2026-06-18"
+        assert format_expires_at("2026-06-18") == "2026-06-18"
 
     def test__format_expires_at_leaves_none_unchanged(self):
-        assert GroupMembersProcessor._format_expires_at(None) is None
+        assert format_expires_at(None) is None
 
     def test__process_groups_formats_date_expires_at_before_sharing(self):
         group = MagicMock()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,6 @@
 import datetime
 
-from gitlabform.util import to_str
+from gitlabform.util import format_expires_at, to_str
 
 
 def test_date_stringification():
@@ -18,3 +18,15 @@ def test_date_stringification():
     }
     output = to_str(example_project_config)
     assert type(output) is str
+
+
+def test_format_expires_at_converts_date_to_gitlab_string():
+    assert format_expires_at(datetime.date(2026, 6, 18)) == "2026-06-18"
+
+
+def test_format_expires_at_leaves_string_unchanged():
+    assert format_expires_at("2026-06-18") == "2026-06-18"
+
+
+def test_format_expires_at_leaves_none_unchanged():
+    assert format_expires_at(None) is None


### PR DESCRIPTION
## Summary
- normalize `group_members` `expires_at` values to GitLab's `YYYY-MM-DD` string format before comparing or saving user memberships
- apply the same normalization to `group_members.groups` / share-with-group expiry values
- add focused unit coverage for date, string, and missing expiry values

Fixes #1320

## Validation
- `uv run qa lint ruff gitlabform/processors/group/group_members_processor.py tests/unit/processors/test_group_members_processor.py`
- `uv run qa format --check gitlabform/processors/group/group_members_processor.py tests/unit/processors/test_group_members_processor.py`
- `uv run qa test tests/unit/processors/test_group_members_processor.py`
- `uv run qa test tests/unit`

I did not run acceptance tests because they require a disposable GitLab instance/Docker setup.
