### PR TITLE
fix(merge_requests_approval_rules): stop redundant edit calls on unchanged rules

### DIFF
--- a/gitlabform/processors/project/merge_requests_approval_rules.py
+++ b/gitlabform/processors/project/merge_requests_approval_rules.py
@@ -15,3 +15,24 @@ class MergeRequestsApprovalRules(MultipleEntitiesProcessor):
             defining=Key("name"),
             required_to_create_or_update=And(Key("name"), Key("approvals_required")),
         )
+
+    def _needs_update(self, entity_in_gitlab: dict, entity_in_configuration: dict) -> bool:
+        # GitLab returns users/groups as lists of objects and protected_branches as list
+        # of objects with a "name" field, while the config (post-transform) has user_ids /
+        # group_ids as int lists and protected_branches as list of names. Without
+        # normalization the base _needs_update always triggers an update, even when nothing
+        # changed. We normalize both sides unconditionally so keys line up regardless of
+        # whether GitLab omitted an empty list or the user omitted the field in config.
+        gitlab_norm = dict(entity_in_gitlab)
+        gitlab_norm["user_ids"] = sorted(u["id"] for u in gitlab_norm.pop("users", []))
+        gitlab_norm["group_ids"] = sorted(g["id"] for g in gitlab_norm.pop("groups", []))
+        gitlab_norm["protected_branches"] = sorted(b["name"] for b in gitlab_norm.get("protected_branches", []))
+
+        # edit_approval_rule treats missing user_ids/group_ids/protected_branches
+        # in config as "clear them", so mirror that here to keep the comparison honest.
+        config_norm = dict(entity_in_configuration)
+        config_norm["user_ids"] = sorted(config_norm.get("user_ids", []))
+        config_norm["group_ids"] = sorted(config_norm.get("group_ids", []))
+        config_norm["protected_branches"] = sorted(config_norm.get("protected_branches", []))
+
+        return super()._needs_update(gitlab_norm, config_norm)

--- a/tests/acceptance/premium/test_merge_request_approval_rules.py
+++ b/tests/acceptance/premium/test_merge_request_approval_rules.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from gitlabform.gitlab import AccessLevel
@@ -546,3 +548,54 @@ class TestMergeRequestApprovers:
         coverage_check_approval_rule_details = mr_approval_rules_under_this_project[1]
         assert coverage_check_approval_rule_details.name == "Coverage-Check"
         assert coverage_check_approval_rule_details.approvals_required == 0
+
+    def test__no_churn_when_config_unchanged(
+        self,
+        project_for_function,
+        group_with_one_owner_and_two_developers,
+        make_user,
+        branch_for_function,
+        caplog,
+    ):
+        user1 = make_user(AccessLevel.DEVELOPER, add_to_project=False)
+        project_for_function.members.create({"user_id": user1.id, "access_level": AccessLevel.DEVELOPER.value})
+
+        config = f"""
+            projects_and_groups:
+              {project_for_function.path_with_namespace}:
+                branches:
+                  {branch_for_function}:
+                    protected: true
+                    push_access_level: no access
+                    merge_access_level: developer
+                    unprotect_access_level: maintainer
+                merge_requests_approval_rules:
+                  standard:
+                    approvals_required: 1
+                    name: "Regular approvers"
+                    users:
+                      - {user1.username}
+                  security:
+                    approvals_required: 2
+                    name: "Extra Security Team approval for selected branches"
+                    users:
+                      - {user1.username}
+                    groups:
+                      - {group_with_one_owner_and_two_developers.full_path}
+                    protected_branches:
+                      - {branch_for_function}
+            """
+
+        run_gitlabform(config, project_for_function)
+        assert len(project_for_function.approvalrules.list()) >= 2
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO):
+            run_gitlabform(config, project_for_function)
+
+        assert (
+            "Editing standard of merge_requests_approval_rules" not in caplog.text
+        ), f"Expected no edit for unchanged 'standard' rule, got: {caplog.text}"
+        assert (
+            "Editing security of merge_requests_approval_rules" not in caplog.text
+        ), f"Expected no edit for unchanged 'security' rule, got: {caplog.text}"

--- a/tests/unit/processors/test_merge_requests_approval_rules_processor.py
+++ b/tests/unit/processors/test_merge_requests_approval_rules_processor.py
@@ -1,0 +1,120 @@
+from unittest.mock import MagicMock, patch
+
+from gitlabform.processors.project.merge_requests_approval_rules import MergeRequestsApprovalRules
+
+
+class TestMergeRequestsApprovalRulesProcessor:
+    def setup_method(self):
+        self.gitlab = MagicMock()
+        with patch("gitlabform.processors.abstract_processor.GitlabWrapper"):
+            self.processor = MergeRequestsApprovalRules(self.gitlab)
+
+    @staticmethod
+    def _gitlab_rule(
+        name="standard",
+        approvals_required=1,
+        users=None,
+        groups=None,
+        protected_branches=None,
+        applies_to_all_protected_branches=False,
+        rule_type="regular",
+    ):
+        return {
+            "id": 1,
+            "name": name,
+            "rule_type": rule_type,
+            "report_type": None,
+            "eligible_approvers": [],
+            "approvals_required": approvals_required,
+            "users": users or [],
+            "groups": groups or [],
+            "contains_hidden_groups": False,
+            "protected_branches": protected_branches or [],
+            "applies_to_all_protected_branches": applies_to_all_protected_branches,
+        }
+
+    def test_no_update_when_users_match(self):
+        gitlab_rule = self._gitlab_rule(
+            users=[{"id": 5, "username": "alice"}, {"id": 7, "username": "bob"}],
+        )
+        config = {"name": "standard", "approvals_required": 1, "user_ids": [7, 5]}
+
+        assert self.processor._needs_update(gitlab_rule, config) is False
+
+    def test_no_update_when_groups_match(self):
+        gitlab_rule = self._gitlab_rule(groups=[{"id": 3, "name": "sec"}])
+        config = {"name": "standard", "approvals_required": 1, "group_ids": [3]}
+
+        assert self.processor._needs_update(gitlab_rule, config) is False
+
+    def test_no_update_when_protected_branches_match(self):
+        gitlab_rule = self._gitlab_rule(
+            protected_branches=[
+                {"id": 1, "name": "main"},
+                {"id": 2, "name": "release"},
+            ],
+        )
+        config = {
+            "name": "standard",
+            "approvals_required": 1,
+            "protected_branches": ["release", "main"],
+        }
+
+        assert self.processor._needs_update(gitlab_rule, config) is False
+
+    def test_no_update_when_config_omits_user_ids_and_gitlab_has_no_users(self):
+        gitlab_rule = self._gitlab_rule()
+        config = {"name": "standard", "approvals_required": 1}
+
+        assert self.processor._needs_update(gitlab_rule, config) is False
+
+    def test_no_update_when_gitlab_omits_users_groups_protected_branches_keys(self):
+        gitlab_rule = {
+            "id": 1,
+            "name": "standard",
+            "rule_type": "regular",
+            "approvals_required": 1,
+        }
+        config = {"name": "standard", "approvals_required": 1}
+
+        assert self.processor._needs_update(gitlab_rule, config) is False
+
+    def test_update_when_user_ids_differ(self):
+        gitlab_rule = self._gitlab_rule(users=[{"id": 5, "username": "alice"}])
+        config = {"name": "standard", "approvals_required": 1, "user_ids": [9]}
+
+        assert self.processor._needs_update(gitlab_rule, config) is True
+
+    def test_update_when_config_clears_users_but_gitlab_has_users(self):
+        gitlab_rule = self._gitlab_rule(users=[{"id": 5, "username": "alice"}])
+        config = {"name": "standard", "approvals_required": 1}
+
+        assert self.processor._needs_update(gitlab_rule, config) is True
+
+    def test_update_when_protected_branches_differ(self):
+        gitlab_rule = self._gitlab_rule(
+            protected_branches=[{"id": 1, "name": "main"}],
+        )
+        config = {
+            "name": "standard",
+            "approvals_required": 1,
+            "protected_branches": ["release"],
+        }
+
+        assert self.processor._needs_update(gitlab_rule, config) is True
+
+    def test_update_when_approvals_required_changes(self):
+        gitlab_rule = self._gitlab_rule(approvals_required=1)
+        config = {"name": "standard", "approvals_required": 2}
+
+        assert self.processor._needs_update(gitlab_rule, config) is True
+
+    def test_no_update_for_any_approver_rule(self):
+        gitlab_rule = self._gitlab_rule(rule_type="any_approver", approvals_required=0)
+        config = {
+            "name": "standard",
+            "approvals_required": 0,
+            "rule_type": "any_approver",
+        }
+
+        assert self.processor._needs_update(gitlab_rule, config) is False


### PR DESCRIPTION
The base _needs_update compared config keys (user_ids / group_ids / protected_branches as names) against the GitLab response shape (users / groups as object lists, protected_branches as dicts), so keys_only_in_configuration always fired and every run issued a PUT.

Override _needs_update to normalize both sides before comparing, and mirror edit_approval_rule's semantics that a missing list in config means "clear it".