### PR TITLE
fix: escape regex as raw string in core.py

### DIFF
--- a/gitlabform/gitlab/core.py
+++ b/gitlabform/gitlab/core.py
@@ -117,7 +117,7 @@ class GitLabCore:
         current_version = "0.0.0"
 
         if self.version != "unknown":
-            sem_ver_regex = "^\d*\.\d*\.\d*"
+            sem_ver_regex = r"^\d*\.\d*\.\d*"
             # Get the pure semantic version from self.version, for example Gitlab will return 18.2.1-ee
             match = re.search(sem_ver_regex, self.version)
             if match:


### PR DESCRIPTION
The following message appears in the log:

```
/app/.venv/lib/python3.14/site-packages/gitlabform/gitlab/core.py:120: SyntaxWarning: "\d" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\d"? A raw string is also an option.
  sem_ver_regex = "^\d*\.\d*\.\d*"
```

So, we use raw string for semver regex to silence SyntaxWarning on Python 3.14