### PR TITLE
refactor(processors): migrate hooks to MultipleEntitiesProcessor

### DIFF
--- a/gitlabform/processors/group/group_hooks_processor.py
+++ b/gitlabform/processors/group/group_hooks_processor.py
@@ -1,75 +1,56 @@
-from logging import debug, warning
-from typing import Dict, Any, List
+from logging import warning
 
-from gitlab.base import RESTObject, RESTObjectList
 from gitlab.v4.objects import Group
-from gitlab.v4.objects import GroupHook
 
 from gitlabform.gitlab import GitLab
-from gitlabform.processors.abstract_processor import AbstractProcessor
+from gitlabform.processors.defining_keys import Key
+from gitlabform.processors.multiple_entities_processor import MultipleEntitiesProcessor
 
 
-class GroupHooksProcessor(AbstractProcessor):
+class GroupHooksProcessor(MultipleEntitiesProcessor):
     def __init__(self, gitlab: GitLab):
-        super().__init__("group_hooks", gitlab)
+        super().__init__(
+            "group_hooks",
+            gitlab,
+            list_method_name=self._list_hooks,
+            add_method_name=self._add_hook,
+            delete_method_name=self._delete_hook,
+            edit_method_name=self._edit_hook,
+            defining=Key("url"),
+            required_to_create_or_update=Key("url"),
+        )
 
-    def _can_proceed(self, project_or_group: str, configuration: dict):
+    def _can_proceed(self, project_or_group: str, configuration: dict) -> bool:
         if not self.gitlab.enterprise:
-            hooks_in_config = configuration["group_hooks"]
-            if hooks_in_config is not None and len(hooks_in_config) > 0:
-                # Only raise error if user has defined hooks in config, otherwise exit silently out of processor
+            hooks_in_config = configuration.get("group_hooks") or {}
+            if len(hooks_in_config) > 0:
+                # Only warn if the user has actually configured hooks; otherwise exit silently.
                 warning("GitLab Community Edition does not support Group Webhooks")
-
             return False
-
         return True
 
     def _process_configuration(self, group_path_and_name: str, configuration: dict):
-        hooks_in_config: tuple[str, ...] = tuple(x for x in sorted(configuration["group_hooks"]) if x != "enforce")
-
-        debug("Processing group hooks...")
-        group: Group = self.gl.get_group_by_path_cached(group_path_and_name)
-        group_hooks: list[GroupHook] = group.hooks.list(get_all=True)
-
-        for hook in hooks_in_config:
-            hook_in_gitlab: RESTObject | None = next((h for h in group_hooks if h.url == hook), None)
-            hook_config = {"url": hook}
-            hook_config.update(configuration["group_hooks"][hook])
-
-            hook_id = hook_in_gitlab.id if hook_in_gitlab else None
-
-            # Process hooks configured for deletion
-            if configuration.get("group_hooks|" + hook + "|delete"):
-                if hook_id:
-                    debug(f"Deleting group hook '{hook}'")
-                    group.hooks.delete(hook_id)
-                    debug(f"Deleted group hook '{hook}'")
-                else:
-                    debug(f"Not deleting group hook '{hook}', because it doesn't exist")
+        # The yaml alias for each hook IS the url, but the nested dict doesn't include it.
+        # MultipleEntitiesProcessor matches entities via defining keys, so we inject `url` here.
+        hooks = configuration.get(self.configuration_name) or {}
+        for alias, hook_config in hooks.items():
+            if alias == "enforce":
                 continue
+            if isinstance(hook_config, dict):
+                hook_config.setdefault("url", alias)
+        super()._process_configuration(group_path_and_name, configuration)
 
-            # Process new hook creation
-            if not hook_id:
-                debug(f"Creating group hook '{hook}'")
-                created_hook: RESTObject = group.hooks.create(hook_config)
-                debug(f"Created group hook: {created_hook}")
-                continue
+    def _group(self, group_path_and_name: str) -> Group:
+        return self.gl.get_group_by_path_cached(group_path_and_name)
 
-            # Processing existing hook updates
-            gl_hook: dict = hook_in_gitlab.asdict() if hook_in_gitlab else {}
-            if self._needs_update(gl_hook, hook_config):
-                debug(f"The group hook '{hook}' config is different from what's in gitlab OR it contains a token")
-                debug(f"Updating group hook '{hook}'")
-                updated_hook: Dict[str, Any] = group.hooks.update(hook_id, hook_config)
-                debug(f"Updated group hook: {updated_hook}")
-            else:
-                debug(f"Group hook '{hook}' remains unchanged")
+    def _list_hooks(self, group_path_and_name: str) -> list[dict]:
+        return [h.asdict() for h in self._group(group_path_and_name).hooks.list(get_all=True)]
 
-        # Process hook config enforcements
-        if configuration.get("group_hooks|enforce"):
-            for gh in group_hooks:
-                if gh.url not in hooks_in_config:
-                    debug(
-                        f"Deleting group hook '{gh.url}' currently setup in the group but it is not in the configuration and enforce is enabled"
-                    )
-                    group.hooks.delete(gh.id)
+    def _add_hook(self, group_path_and_name: str, hook_config: dict) -> None:
+        self._group(group_path_and_name).hooks.create(hook_config)
+
+    def _delete_hook(self, group_path_and_name: str, hook_in_gitlab: dict) -> None:
+        self._group(group_path_and_name).hooks.delete(hook_in_gitlab["id"])
+
+    def _edit_hook(self, group_path_and_name: str, hook_in_gitlab: dict, hook_config: dict) -> None:
+        self._group(group_path_and_name).hooks.update(hook_in_gitlab["id"], hook_config)

--- a/gitlabform/processors/multiple_entities_processor.py
+++ b/gitlabform/processors/multiple_entities_processor.py
@@ -130,6 +130,12 @@ class MultipleEntitiesProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
         # add c) (or do nothing if marked as "delete")
 
         for entity_name, entity_config in entities_only_in_configuration.items():
+            if entity_config.get("delete", False):
+                info(
+                    f" * Not deleting {entity_name} of {self.configuration_name} in {project_or_group}"
+                    f" - it doesn't exist."
+                )
+                continue
             self._validate_required_to_create_or_update(project_or_group, entity_name, entity_config)
             info(f" * Adding {entity_name} of {self.configuration_name} in {project_or_group}")
             self.add_method(project_or_group, entity_config)

--- a/gitlabform/processors/project/hooks_processor.py
+++ b/gitlabform/processors/project/hooks_processor.py
@@ -1,64 +1,45 @@
-from logging import debug
-from typing import Dict, Any, List
-
-from gitlab.base import RESTObject, RESTObjectList
 from gitlab.v4.objects import Project
-from gitlab.v4.objects import ProjectHook
 
 from gitlabform.gitlab import GitLab
-from gitlabform.processors.abstract_processor import AbstractProcessor
+from gitlabform.processors.defining_keys import Key
+from gitlabform.processors.multiple_entities_processor import MultipleEntitiesProcessor
 
 
-class HooksProcessor(AbstractProcessor):
+class HooksProcessor(MultipleEntitiesProcessor):
     def __init__(self, gitlab: GitLab):
-        super().__init__("hooks", gitlab)
+        super().__init__(
+            "hooks",
+            gitlab,
+            list_method_name=self._list_hooks,
+            add_method_name=self._add_hook,
+            delete_method_name=self._delete_hook,
+            edit_method_name=self._edit_hook,
+            defining=Key("url"),
+            required_to_create_or_update=Key("url"),
+        )
 
     def _process_configuration(self, project_and_group: str, configuration: dict):
-        debug("Processing hooks...")
-        project: Project = self.gl.get_project_by_path_cached(project_and_group)
-        project_hooks: list[ProjectHook] = project.hooks.list(get_all=True)
-
-        hooks_in_config: tuple[str, ...] = tuple(x for x in sorted(configuration["hooks"]) if x != "enforce")
-
-        for hook in hooks_in_config:
-            hook_in_gitlab: RESTObject | None = next((h for h in project_hooks if h.url == hook), None)
-            hook_config = {"url": hook}
-            hook_config.update(configuration["hooks"][hook])
-
-            hook_id = hook_in_gitlab.id if hook_in_gitlab else None
-
-            # Process hooks configured for deletion
-            if configuration.get("hooks|" + hook + "|delete"):
-                if hook_id:
-                    debug(f"Deleting hook '{hook}'")
-                    project.hooks.delete(hook_id)
-                    debug(f"Deleted hook '{hook}'")
-                else:
-                    debug(f"Not deleting hook '{hook}', because it doesn't exist")
+        # The yaml alias for each hook IS the url, but the nested dict doesn't include it.
+        # MultipleEntitiesProcessor matches entities via defining keys, so we inject `url` here.
+        hooks = configuration.get(self.configuration_name) or {}
+        for alias, hook_config in hooks.items():
+            if alias == "enforce":
                 continue
+            if isinstance(hook_config, dict):
+                hook_config.setdefault("url", alias)
+        super()._process_configuration(project_and_group, configuration)
 
-            # Process new hook creation
-            if not hook_id:
-                debug(f"Creating hook '{hook}'")
-                created_hook: RESTObject = project.hooks.create(hook_config)
-                debug(f"Created hook: {created_hook}")
-                continue
+    def _project(self, project_and_group: str) -> Project:
+        return self.gl.get_project_by_path_cached(project_and_group)
 
-            # Processing existing hook updates
-            gl_hook: dict = hook_in_gitlab.asdict() if hook_in_gitlab else {}
-            if self._needs_update(gl_hook, hook_config):
-                debug(f"The hook '{hook}' config is different from what's in gitlab OR it contains a token")
-                debug(f"Updating hook '{hook}'")
-                updated_hook: Dict[str, Any] = project.hooks.update(hook_id, hook_config)
-                debug(f"Updated hook: {updated_hook}")
-            else:
-                debug(f"Hook '{hook}' remains unchanged")
+    def _list_hooks(self, project_and_group: str) -> list[dict]:
+        return [h.asdict() for h in self._project(project_and_group).hooks.list(get_all=True)]
 
-        # Process hook config enforcements
-        if configuration.get("hooks|enforce"):
-            for gh in project_hooks:
-                if gh.url not in hooks_in_config:
-                    debug(
-                        f"Deleting hook '{gh.url}' currently setup in the project but it is not in the configuration and enforce is enabled"
-                    )
-                    project.hooks.delete(gh.id)
+    def _add_hook(self, project_and_group: str, hook_config: dict) -> None:
+        self._project(project_and_group).hooks.create(hook_config)
+
+    def _delete_hook(self, project_and_group: str, hook_in_gitlab: dict) -> None:
+        self._project(project_and_group).hooks.delete(hook_in_gitlab["id"])
+
+    def _edit_hook(self, project_and_group: str, hook_in_gitlab: dict, hook_config: dict) -> None:
+        self._project(project_and_group).hooks.update(hook_in_gitlab["id"], hook_config)

--- a/tests/acceptance/standard/test_group_hooks.py
+++ b/tests/acceptance/standard/test_group_hooks.py
@@ -117,7 +117,7 @@ class TestGroupHooksProcessor:
         # The hook contains a token, which is a secret. So, cannot confirm whether it's different from
         # existing config in. This is why the hook is always updated. The hook's current config is also
         # different from when it was created in previous test case.
-        assert f"Updating group hook '{first_url}'" in caplog.text
+        assert f"Editing {first_url} of group_hooks in {group.full_path}" in caplog.text
         assert updated_first_hook.asdict() != first_hook.asdict()
         # push_events stays False from previous test case config
         assert (
@@ -128,7 +128,7 @@ class TestGroupHooksProcessor:
 
         # The second hook should remain unchanged.
         # The hook did not change from the previous test case. So, updating it is not necessary.
-        assert f"Group hook '{second_url}' remains unchanged" in caplog.text
+        assert f"{second_url} of group_hooks in {group.full_path} doesn't need an update." in caplog.text
         assert updated_second_hook.asdict() == second_hook.asdict()
         assert (
             updated_second_hook.job_events,
@@ -140,7 +140,7 @@ class TestGroupHooksProcessor:
         # In the current run/config the token is removed but all other configs remain same.
         # GitLabForm does not have memory or awareness of previous configs. So, comparing with
         # existing config in GitLab, the hook did not change and is not updated.
-        assert f"Group hook '{third_url}' remains unchanged" in caplog.text
+        assert f"{third_url} of group_hooks in {group.full_path} doesn't need an update." in caplog.text
         assert updated_third_hook.asdict() == third_hook.asdict()
         assert (
             updated_third_hook.push_events,
@@ -188,7 +188,10 @@ class TestGroupHooksProcessor:
         assert third_hook_after_test.asdict() == third_hook_before_test.asdict()
         # The last hook configured for deletion but it was never setup in gitlab.
         # Ensure expected error message is reported.
-        assert f"Not deleting group hook '{non_existent_hook_url}', because it doesn't exist" in caplog.text
+        assert (
+            f"Not deleting {non_existent_hook_url} of group_hooks in {group.full_path}"
+            " - it doesn't exist." in caplog.text
+        )
 
     def test_hooks_enforce(self, gl, group, urls):
         first_url, second_url, third_url = urls

--- a/tests/acceptance/standard/test_hooks.py
+++ b/tests/acceptance/standard/test_hooks.py
@@ -99,7 +99,7 @@ class TestHooksProcessor:
         # The hook contains a token, which is a secret. So, cannot confirm whether it's different from
         # existing config in. This is why the hook is always updated. The hook's current config is also
         # different from when it was created in previous test case.
-        assert f"Updating hook '{first_url}'" in caplog.text
+        assert f"Editing {first_url} of hooks in {target}" in caplog.text
         assert updated_first_hook.asdict() != first_hook.asdict()
         # push_events stays False from previous test case config
         assert (
@@ -110,7 +110,7 @@ class TestHooksProcessor:
 
         # The second hook should remain unchanged.
         # The hook did not change from the previous test case. So, updating it is not necessary.
-        assert f"Hook '{second_url}' remains unchanged" in caplog.text
+        assert f"{second_url} of hooks in {target} doesn't need an update." in caplog.text
         assert updated_second_hook.asdict() == second_hook.asdict()
         assert (
             updated_second_hook.job_events,
@@ -122,7 +122,7 @@ class TestHooksProcessor:
         # In the current run/config the token is removed but all other configs remain same.
         # GitLabForm does not have memory or awareness of previous configs. So, comparing with
         # existing config in GitLab, the hook did not change and is not updated.
-        assert f"Hook '{third_url}' remains unchanged" in caplog.text
+        assert f"{third_url} of hooks in {target} doesn't need an update." in caplog.text
         assert updated_third_hook.asdict() == third_hook.asdict()
         assert (
             updated_third_hook.push_events,
@@ -172,7 +172,7 @@ class TestHooksProcessor:
 
         # The last hook configured for deletion but it was never setup in gitlab.
         # Ensure expected error message is reported.
-        assert f"Not deleting hook '{non_existent_hook_url}', because it doesn't exist" in caplog.text
+        assert f"Not deleting {non_existent_hook_url} of hooks in {target} - it doesn't exist." in caplog.text
 
     def test_hooks_enforce(self, gl, group, project, urls):
         target = project.path_with_namespace


### PR DESCRIPTION
Fold HooksProcessor and GroupHooksProcessor into the existing MultipleEntitiesProcessor and fix a bug where `delete: true` on an entity absent from GitLab would fall through to the create branch contrary to the existing "do nothing if marked as 'delete'" comment).