### PR TITLE
fix(processors): skip delete:true entities absent from GitLab

### DIFF
--- a/gitlabform/processors/multiple_entities_processor.py
+++ b/gitlabform/processors/multiple_entities_processor.py
@@ -130,6 +130,12 @@ class MultipleEntitiesProcessor(AbstractProcessor, metaclass=abc.ABCMeta):
         # add c) (or do nothing if marked as "delete")
 
         for entity_name, entity_config in entities_only_in_configuration.items():
+            if entity_config.get("delete", False):
+                info(
+                    f" * Not deleting {entity_name} of {self.configuration_name} in {project_or_group}"
+                    f" - it doesn't exist."
+                )
+                continue
             self._validate_required_to_create_or_update(project_or_group, entity_name, entity_config)
             info(f" * Adding {entity_name} of {self.configuration_name} in {project_or_group}")
             self.add_method(project_or_group, entity_config)

--- a/tests/unit/processors/test_multiple_entities_processor.py
+++ b/tests/unit/processors/test_multiple_entities_processor.py
@@ -1,0 +1,32 @@
+from unittest.mock import MagicMock, patch
+
+from gitlabform.processors.defining_keys import Key
+from gitlabform.processors.multiple_entities_processor import MultipleEntitiesProcessor
+
+
+class TestMultipleEntitiesProcessor:
+    def setup_method(self):
+        self.gitlab = MagicMock()
+        self.list_method = MagicMock(return_value=[])
+        self.add_method = MagicMock()
+        self.delete_method = MagicMock()
+        self.edit_method = MagicMock()
+        with patch("gitlabform.processors.abstract_processor.GitlabWrapper"):
+            self.processor = MultipleEntitiesProcessor(
+                configuration_name="entities",
+                gitlab=self.gitlab,
+                list_method_name=self.list_method,
+                add_method_name=self.add_method,
+                delete_method_name=self.delete_method,
+                edit_method_name=self.edit_method,
+                defining=Key("name"),
+                required_to_create_or_update=Key("name"),
+            )
+
+    def test_delete_true_on_entity_absent_from_gitlab_does_not_create_it(self):
+        configuration = {"entities": {"ghost": {"name": "ghost", "delete": True}}}
+
+        self.processor._process_configuration("group/x", configuration)
+
+        self.add_method.assert_not_called()
+        self.delete_method.assert_not_called()


### PR DESCRIPTION
Previously, when a config entry had `delete: true` for an entity that wasn't in GitLab, `MultipleEntitiesProcessor` fell through to the create branch instead of skipping.