### PR TITLE
docs: update license renewal process

### DIFF
--- a/docs/contrib/workflows.md
+++ b/docs/contrib/workflows.md
@@ -16,6 +16,12 @@ only on the main repository.
 
 ## License management
 
-Requesting new Premium/Ultimate Licenses is done via GitLab's Contribution to EE process [here](https://handbook.gitlab.com/handbook/marketing/developer-relations/contributor-success/community-contributors-workflows/#contributing-to-the-gitlab-enterprise-edition-ee).
+Requesting new Premium/Ultimate Licenses is done via GitLab's Contribution to EE process [here](https://handbook.gitlab.com/handbook/marketing/developer-relations/engineering/community-contributors-workflows/#contributing-to-the-gitlab-enterprise-edition-ee).
+
+To request a license, create an issue via the [Wider Community Contributor License Request](https://gitlab.com/gitlab-org/developer-relations/contributor-success/team-task/-/issues/new?issuable_template=contributor_ee_license_request) template, and select 'New Request'. Use the following text in the request:
+
+> As a Maintainer of GitlabForm, I like to requesting new Premium and Ultimate License for https://github.com/gitlabform/gitlabform.
+
+Note that the Premium and Ultimate licenses are sent separately, and there may be some time between receiving them.
 
 As a Maintainer, when you receive a new license key, please add/update it to the GitHub Repository Secrets.


### PR DESCRIPTION
Updates the license renewal documentation in the GitHub Workflows docs.