### PR TITLE
fix: catch GitlabCreateError and GitlabDeleteError when modifying files on protected branches

### DIFF
--- a/gitlabform/processors/project/files_processor.py
+++ b/gitlabform/processors/project/files_processor.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from logging import debug, info, warning, critical
 
 from jinja2 import Environment, FileSystemLoader
-from gitlab import GitlabGetError, GitlabUpdateError, GitlabListError
+from gitlab import GitlabCreateError, GitlabDeleteError, GitlabGetError, GitlabListError, GitlabUpdateError
 from gitlab.v4.objects import Project, ProjectFile, ProjectBranch
 from gitlab.base import RESTObject
 
@@ -235,7 +235,7 @@ class FilesProcessor(AbstractProcessor):
                 new_content,
             )
 
-        except GitlabUpdateError as e:
+        except (GitlabUpdateError, GitlabCreateError, GitlabDeleteError) as e:
             if (
                 e.response_code == 400 or e.response_code == 403
             ) and "You are not allowed to push into this branch" in e.error_message:

--- a/tests/acceptance/standard/test_files.py
+++ b/tests/acceptance/standard/test_files.py
@@ -177,6 +177,53 @@ class TestFiles:
                 break
         assert is_protected == True
 
+    def test__add_new_file_strongly_protected_branch(self, project, no_access_branch, is_enterprise_edition):
+        """
+        Creating a NEW file (as opposed to modifying an existing one) goes through
+        python-gitlab's files.create(), which raises GitlabCreateError instead of
+        GitlabUpdateError. This test validates that the temporary unprotect/re-protect
+        fallback also works in that case.
+        """
+        protected_branch = project.protectedbranches.get(no_access_branch.name)
+        push_access_level = protected_branch.push_access_levels[0]["access_level"]
+        merge_access_level = protected_branch.merge_access_levels[0]["access_level"]
+
+        # Unprotect access level is not available in GitLab CE.
+        unprotect_access_level_config = ""
+        if is_enterprise_edition:
+            unprotect_access_level = protected_branch.unprotect_access_levels[0]["access_level"]
+            unprotect_access_level_config = f"unprotect_access_level: {unprotect_access_level}"
+
+        add_file_to_protected_branch = f"""
+            projects_and_groups:
+              {project.path_with_namespace}:
+                branches:
+                  {no_access_branch.name}:
+                    protected: true
+                    push_access_level: {push_access_level}
+                    merge_access_level: {merge_access_level}
+                    {unprotect_access_level_config}
+                files:
+                  "newly-created-file.txt":
+                    overwrite: true
+                    branches:
+                      - {no_access_branch.name}
+                    content: "Content of a new file on a strongly protected branch"
+            """
+
+        run_gitlabform(add_file_to_protected_branch, project)
+
+        project_file = project.files.get(ref=no_access_branch.name, file_path="newly-created-file.txt")
+        assert project_file.decode().decode("utf-8") == "Content of a new file on a strongly protected branch"
+
+        # the file must not exist on main
+        with pytest.raises(GitlabGetError):
+            project.files.get(ref="main", file_path="newly-created-file.txt")
+
+        # check that the branch protection was restored
+        protected_branches = project.protectedbranches.list()
+        assert any(pb.name == no_access_branch.name for pb in protected_branches)
+
     def test__delete_file_protected_branch(self, project, branch):
         set_file_specific_branch = f"""
             projects_and_groups:

--- a/tests/acceptance/standard/test_files.py
+++ b/tests/acceptance/standard/test_files.py
@@ -224,6 +224,51 @@ class TestFiles:
         protected_branches = project.protectedbranches.list()
         assert any(pb.name == no_access_branch.name for pb in protected_branches)
 
+    def test__delete_file_strongly_protected_branch(self, project, no_access_branch, is_enterprise_edition):
+        """
+        Deleting a file goes through python-gitlab's file.delete(), which raises
+        GitlabDeleteError instead of GitlabUpdateError. This test validates that
+        the temporary unprotect/re-protect fallback also works in that case.
+        """
+        protected_branch = project.protectedbranches.get(no_access_branch.name)
+        push_access_level = protected_branch.push_access_levels[0]["access_level"]
+        merge_access_level = protected_branch.merge_access_levels[0]["access_level"]
+
+        # Unprotect access level is not available in GitLab CE.
+        unprotect_access_level_config = ""
+        if is_enterprise_edition:
+            unprotect_access_level = protected_branch.unprotect_access_levels[0]["access_level"]
+            unprotect_access_level_config = f"unprotect_access_level: {unprotect_access_level}"
+
+        delete_file_on_protected_branch = f"""
+            projects_and_groups:
+              {project.path_with_namespace}:
+                branches:
+                  {no_access_branch.name}:
+                    protected: true
+                    push_access_level: {push_access_level}
+                    merge_access_level: {merge_access_level}
+                    {unprotect_access_level_config}
+                files:
+                  "README.md":
+                    branches:
+                      - {no_access_branch.name}
+                    delete: true
+            """
+
+        run_gitlabform(delete_file_on_protected_branch, project)
+
+        with pytest.raises(GitlabGetError):
+            project.files.get(ref=no_access_branch.name, file_path="README.md")
+
+        # the file must still exist on main
+        project_file = project.files.get(ref="main", file_path="README.md")
+        assert project_file.decode().decode("utf-8") == DEFAULT_README
+
+        # check that the branch protection was restored
+        protected_branches = project.protectedbranches.list()
+        assert any(pb.name == no_access_branch.name for pb in protected_branches)
+
     def test__delete_file_protected_branch(self, project, branch):
         set_file_specific_branch = f"""
             projects_and_groups:


### PR DESCRIPTION
## Summary
- Widen the exception handling in `FilesProcessor.modify_file_dealing_with_branch_protection` to also catch `GitlabCreateError` and `GitlabDeleteError`, not just `GitlabUpdateError`, so the temporary unprotect/re-protect fallback also applies when *creating* a new file (`project.files.create()`) or *deleting* a file (`file.delete()`) on a strongly protected branch.
- Add a regression test (`test__add_new_file_strongly_protected_branch`) covering the create path on a `no access` protected branch, which previously failed with an uncaught `GitlabCreateError`.

Fixes #1360

## Test plan
- [x] Added `test__add_new_file_strongly_protected_branch` to `tests/acceptance/standard/test_files.py`, modeled after the existing `test__set_file_strongly_protected_branch` (modify path), but exercising file *creation* instead.