### PR TITLE
fix(files): use add instead of delete in commit message for new files

### DIFF
--- a/gitlabform/processors/project/files_processor.py
+++ b/gitlabform/processors/project/files_processor.py
@@ -302,9 +302,7 @@ class FilesProcessor(AbstractProcessor):
                     "file_path": file_to_operate_on,
                     "branch": branch.name,
                     "content": new_content,
-                    "commit_message": self.get_commit_message_for_file_change(
-                        "delete", file_to_operate_on, configuration
-                    ),
+                    "commit_message": self.get_commit_message_for_file_change("add", file_to_operate_on, configuration),
                 }
             )
         elif operation == "delete" and isinstance(file_to_operate_on, ProjectFile):

--- a/tests/acceptance/standard/test_files.py
+++ b/tests/acceptance/standard/test_files.py
@@ -216,6 +216,9 @@ class TestFiles:
         project_file = project.files.get(ref=no_access_branch.name, file_path="newly-created-file.txt")
         assert project_file.decode().decode("utf-8") == "Content of a new file on a strongly protected branch"
 
+        branch = project.branches.get(no_access_branch.name)
+        assert branch.commit["message"] == "Automated add made by gitlabform"
+
         # the file must not exist on main
         with pytest.raises(GitlabGetError):
             project.files.get(ref="main", file_path="newly-created-file.txt")


### PR DESCRIPTION
The `add` branch of just_modify_file passed "delete" as the operation string to get_commit_message_for_file_change, producing "Automated delete made by gitlabform" for newly created files.

Use "add" so the message reflects what actually happened.
