### PR TITLE
fix(group-members): apply custom roles to group shares

### DIFF
--- a/docs/reference/members.md
+++ b/docs/reference/members.md
@@ -105,34 +105,35 @@ Support is provided for both SaaS and Self-Managed/Dedicated deployments of GitL
 
 !!! warning
 
-    * user `access_level` MUST still be supplied and MUST match the base_access_level of the custom role
+    * `access_level` for a user or `group_access` for an invited group MUST still be supplied and MUST match the
+      `base_access_level` of the custom role
 
 ```yaml
 projects_and_groups:
-group_1/*:
+  group_1/*:
     group_members:
       groups:
         another-group:
-          group_access: no access
+          group_access: reporter
+          member_role: 2
       users:
         my-user:
           access_level: owner
-          member_role: 2
       enforce: true
       keep_bots: false
 ```
 
 ```yaml
 projects_and_groups:
-group_1/*:
+  group_1/*:
     group_members:
       groups:
         another-group:
-          group_access: no access
+          group_access: reporter
+          member_role: Dev_ReadOnly
       users:
         my-user:
           access_level: owner
-          member_role: Dev_ReadOnly
       enforce: true
       keep_bots: false
 ```

--- a/gitlabform/processors/group/group_members_processor.py
+++ b/gitlabform/processors/group/group_members_processor.py
@@ -75,28 +75,49 @@ class GroupMembersProcessor(AbstractProcessor):
             groups_before_by_group_path[shared_with_group["group_full_path"]] = shared_with_group
 
         for share_with_group_path in groups_to_share_with_by_path:
-            group_access_to_set = groups_to_share_with_by_path[share_with_group_path]["group_access"]
+            group_configuration = groups_to_share_with_by_path[share_with_group_path]
+            group_access_to_set = group_configuration["group_access"]
 
-            expires_at_to_set = format_expires_at(groups_to_share_with_by_path[share_with_group_path].get("expires_at"))
+            expires_at_to_set = format_expires_at(group_configuration.get("expires_at"))
+            member_role_id_or_name = group_configuration.get("member_role")
+            member_role_id_to_set = (
+                self.gl.get_member_role_id_cached(member_role_id_or_name, group_being_processed.full_path)
+                if member_role_id_or_name is not None
+                else None
+            )
 
             if share_with_group_path in groups_before_by_group_path:
                 group_access_before = groups_before_by_group_path[share_with_group_path]["group_access_level"]
                 expires_at_before = groups_before_by_group_path[share_with_group_path]["expires_at"]
+                member_role_id_before = groups_before_by_group_path[share_with_group_path].get("member_role_id") or None
 
-                if group_access_before == group_access_to_set and expires_at_before == expires_at_to_set:
+                if (
+                    group_access_before == group_access_to_set
+                    and expires_at_before == expires_at_to_set
+                    and member_role_id_before == member_role_id_to_set
+                ):
                     info(
                         "Nothing to change for group '%s' - same config now as to set.",
                         share_with_group_path,
                     )
                 else:
-                    info(f"Re-adding group {share_with_group_path} to change their access level or expires at.")
+                    info(
+                        f"Re-adding group {share_with_group_path} to change their access level, expires at,"
+                        " or member role."
+                    )
                     share_with_group_id = groups_before_by_group_path[share_with_group_path]["group_id"]
                     # we will remove the group first and then re-add them,
-                    # to ensure that the group has the expected access level
+                    # to ensure that the group has the expected access level, expiration and custom role
                     self._unshare(group_being_processed, share_with_group_id)
 
                     try:
-                        group_being_processed.share(share_with_group_id, group_access_to_set, expires_at_to_set)
+                        self._share(
+                            group_being_processed,
+                            share_with_group_id,
+                            group_access_to_set,
+                            expires_at_to_set,
+                            member_role_id_to_set,
+                        )
                     except GitlabError as e:
                         error(f"Error processing {share_with_group_path}, {e.error_message}")
                         raise e
@@ -108,7 +129,13 @@ class GroupMembersProcessor(AbstractProcessor):
 
                 share_with_group_id = self.gl.get_group_id(share_with_group_path)
                 try:
-                    group_being_processed.share(share_with_group_id, group_access_to_set, expires_at_to_set)
+                    self._share(
+                        group_being_processed,
+                        share_with_group_id,
+                        group_access_to_set,
+                        expires_at_to_set,
+                        member_role_id_to_set,
+                    )
                 except GitlabError as e:
                     error(f"Error processing {share_with_group_path}, {e.error_message}")
                     raise e
@@ -129,6 +156,30 @@ class GroupMembersProcessor(AbstractProcessor):
         info(
             "Group shared with AFTER: %s",
             group_being_processed.members.list(get_all=True),
+        )
+
+    @staticmethod
+    def _share(
+        group_being_processed: Group,
+        share_with_group_id: int,
+        group_access: int,
+        expires_at: str | None,
+        member_role_id: int | None,
+    ):
+        if member_role_id is None:
+            group_being_processed.share(share_with_group_id, group_access, expires_at)
+            return
+
+        # python-gitlab's Group.share() does not currently include member_role_id
+        # in the request body, so use its lower-level API for custom role shares.
+        group_being_processed.manager.gitlab.http_post(
+            f"/groups/{group_being_processed.encoded_id}/share",
+            post_data={
+                "group_id": share_with_group_id,
+                "group_access": group_access,
+                "expires_at": expires_at,
+                "member_role_id": member_role_id,
+            },
         )
 
     @staticmethod

--- a/tests/acceptance/ultimate/test_group_members.py
+++ b/tests/acceptance/ultimate/test_group_members.py
@@ -10,6 +10,28 @@ pytestmark = pytest.mark.requires_ultimate_license
 
 
 class TestGroupMembers:
+    def test__add_group_to_group_members_with_custom_role_by_id(self, gl, group_for_function, groups, random_string):
+        base_access_level = AccessLevel.REPORTER.value
+        member_role_id = self._create_custom_role(gl, base_access_level, random_string)
+
+        add_group = f"""
+              projects_and_groups:
+                {group_for_function.full_path}/*:
+                  group_members:
+                    groups:
+                      {groups[0].full_path}:
+                        group_access: {base_access_level}
+                        member_role: {member_role_id}
+              """
+
+        run_gitlabform(add_group, group_for_function)
+        run_gitlabform(add_group, group_for_function)
+
+        shared_with_groups = gl.groups.get(group_for_function.id).shared_with_groups
+        shared_group = next(group for group in shared_with_groups if group["group_id"] == groups[0].id)
+        assert shared_group["group_access_level"] == base_access_level
+        assert shared_group["member_role_id"] == member_role_id
+
     def test__add_user_to_group_members_with_custom_role_by_id(self, gl, group_for_function, users, random_string):
         base_access_level = AccessLevel.REPORTER.value
         member_role_id = self._create_custom_role(gl, base_access_level, random_string)

--- a/tests/unit/processors/test_group_members_processor.py
+++ b/tests/unit/processors/test_group_members_processor.py
@@ -27,6 +27,129 @@ class TestGroupMembersProcessor:
 
         group.share.assert_called_once_with(123, 30, "2026-06-18")
 
+    def test__process_groups_shares_group_with_custom_role(self):
+        group = MagicMock()
+        group.encoded_id = "parent%2Ftarget"
+        group.full_path = "parent/target"
+        group.shared_with_groups = []
+        self.processor.gl.get_group_id.return_value = 123
+        self.processor.gl.get_member_role_id_cached.return_value = 42
+
+        self.processor._process_groups(
+            group,
+            {
+                "parent/invited": {
+                    "group_access": 20,
+                    "member_role": "Read only",
+                }
+            },
+            enforce_group_members=False,
+        )
+
+        self.processor.gl.get_member_role_id_cached.assert_called_once_with("Read only", "parent/target")
+        group.manager.gitlab.http_post.assert_called_once_with(
+            "/groups/parent%2Ftarget/share",
+            post_data={
+                "group_id": 123,
+                "group_access": 20,
+                "expires_at": None,
+                "member_role_id": 42,
+            },
+        )
+
+    def test__process_groups_does_not_recreate_unchanged_custom_role_share(self):
+        group = MagicMock()
+        group.full_path = "parent/target"
+        group.shared_with_groups = [
+            {
+                "group_id": 123,
+                "group_full_path": "parent/invited",
+                "group_access_level": 20,
+                "expires_at": None,
+                "member_role_id": 42,
+            }
+        ]
+        self.processor.gl.get_member_role_id_cached.return_value = 42
+
+        self.processor._process_groups(
+            group,
+            {
+                "parent/invited": {
+                    "group_access": 20,
+                    "member_role": 42,
+                }
+            },
+            enforce_group_members=False,
+        )
+
+        group.unshare.assert_not_called()
+        group.share.assert_not_called()
+        group.manager.gitlab.http_post.assert_not_called()
+
+    def test__process_groups_recreates_share_when_custom_role_changes(self):
+        group = MagicMock()
+        group.encoded_id = "parent%2Ftarget"
+        group.full_path = "parent/target"
+        group.shared_with_groups = [
+            {
+                "group_id": 123,
+                "group_full_path": "parent/invited",
+                "group_access_level": 20,
+                "expires_at": None,
+                "member_role_id": 41,
+            }
+        ]
+        self.processor.gl.get_member_role_id_cached.return_value = 42
+
+        self.processor._process_groups(
+            group,
+            {
+                "parent/invited": {
+                    "group_access": 20,
+                    "member_role": 42,
+                }
+            },
+            enforce_group_members=False,
+        )
+
+        group.unshare.assert_called_once_with(123)
+        group.manager.gitlab.http_post.assert_called_once_with(
+            "/groups/parent%2Ftarget/share",
+            post_data={
+                "group_id": 123,
+                "group_access": 20,
+                "expires_at": None,
+                "member_role_id": 42,
+            },
+        )
+
+    def test__process_groups_recreates_share_without_custom_role_when_removed_from_config(self):
+        group = MagicMock()
+        group.full_path = "parent/target"
+        group.shared_with_groups = [
+            {
+                "group_id": 123,
+                "group_full_path": "parent/invited",
+                "group_access_level": 20,
+                "expires_at": None,
+                "member_role_id": 42,
+            }
+        ]
+
+        self.processor._process_groups(
+            group,
+            {
+                "parent/invited": {
+                    "group_access": 20,
+                }
+            },
+            enforce_group_members=False,
+        )
+
+        group.unshare.assert_called_once_with(123)
+        group.share.assert_called_once_with(123, 20, None)
+        group.manager.gitlab.http_post.assert_not_called()
+
     def test__process_users_formats_date_expires_at_before_creating_member(self):
         group = MagicMock()
         group.members.list.return_value = []


### PR DESCRIPTION
## Summary

- honor `member_role` for groups configured under `group_members.groups`
- keep group-share updates idempotent by comparing the current `member_role_id`
- document custom roles on group invitations and add unit/Ultimate acceptance coverage

## Root cause

`GroupMembersProcessor._process_groups()` only considered group access and
expiration. It never resolved the configured custom role, and
python-gitlab's high-level `Group.share()` method does not currently include
`member_role_id` in the request body.

## Changes

- resolve a configured member role by name or ID through the existing cached
  member-role lookup
- use python-gitlab's lower-level HTTP API only when a custom role must be sent
- include `member_role_id` in the equality check so unchanged shares are not
  removed and recreated
- restore a regular share when `member_role` is removed from configuration
- add regression tests and update the member configuration examples

## Validation

- `.venv/bin/python -m pytest tests/unit` — 242 passed
- `UV_CACHE_DIR=/private/tmp/gitlabform-uv-cache uv run --no-sync qa lint` — passed
- `UV_CACHE_DIR=/private/tmp/gitlabform-uv-cache uv run --no-sync docs build` — passed
- `UV_CACHE_DIR=/private/tmp/gitlabform-uv-cache uv run --no-sync package build` — passed
- `UV_CACHE_DIR=/private/tmp/gitlabform-uv-cache uv run --no-sync package verify` — passed
- `tests/acceptance/ultimate/test_group_members.py` — collection passed; runtime
  requires a disposable GitLab Ultimate instance and was not available locally

## Compatibility and risk

Existing configurations without `group_members.groups.*.member_role` keep the
same behavior. No migration is required.

When the configured role differs, GitLabForm follows the processor's existing
update strategy of removing and recreating the group invitation. This may
create a brief access gap, but avoids repeated changes once the configured
state is applied.

Closes #1370
