### PR TITLE
fix(gitlab): use metadata endpoint for server information

### DIFF
--- a/gitlabform/gitlab/core.py
+++ b/gitlabform/gitlab/core.py
@@ -74,12 +74,12 @@ class GitLabCore:
         )
 
         try:
-            version_response = self._make_requests_to_api("version")
+            metadata_response = self._make_requests_to_api("metadata")
             info(
-                f"Connected to GitLab version: {version_response['version']} ({version_response['revision']}), Enterprise Edition: {version_response['enterprise']}"
+                f"Connected to GitLab version: {metadata_response['version']} ({metadata_response['revision']}), Enterprise Edition: {metadata_response['enterprise']}"
             )
-            self.version = version_response["version"]
-            self.enterprise = version_response["enterprise"]
+            self.version = metadata_response["version"]
+            self.enterprise = metadata_response["enterprise"]
 
             if self.is_version_less_than("16"):
                 warning(

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -72,7 +72,7 @@ def is_enterprise_edition(gl: Gitlab):
     # Mypy fix: cast the union return type (dict | Response) to dict[str, Any]
     metadata = cast(
         Dict[str, Any],
-        gl.http_get("/version"),
+        gl.http_get("/metadata"),
     )
     return metadata.get("enterprise") or False
 

--- a/tests/unit/gitlab/test_core.py
+++ b/tests/unit/gitlab/test_core.py
@@ -1,7 +1,31 @@
 import os
 
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import call, patch, MagicMock
+
+
+class TestGitLabCoreMetadata:
+    @patch("gitlabform.gitlab.core.requests.Session")
+    @patch("gitlabform.gitlab.core.Configuration")
+    def test_uses_metadata_endpoint_for_server_information(self, mock_configuration, mock_session):
+        mock_configuration.return_value.get.return_value = {
+            "url": "https://gitlab.example.com",
+            "token": "test-token",
+        }
+        mock_session.return_value = MagicMock()
+
+        from gitlabform.gitlab.core import GitLabCore
+
+        with patch.object(GitLabCore, "_make_requests_to_api") as mock_api:
+            mock_api.side_effect = [
+                {"version": "16.0.0", "revision": "abc123", "enterprise": True},
+                {"username": "test_user", "is_admin": True},
+            ]
+            core = GitLabCore()
+
+        assert mock_api.call_args_list == [call("metadata"), call("user")]
+        assert core.version == "16.0.0"
+        assert core.enterprise is True
 
 
 class TestGitLabCoreRetryConfiguration:


### PR DESCRIPTION
## Summary

- use GitLab's `/metadata` endpoint when initializing the API client
- use the same endpoint when acceptance tests detect the GitLab edition
- add a regression test for the initialization request sequence

## Root cause

GitLabForm still queried the legacy-compatible `/version` route even though
the project is moving its minimum supported GitLab version forward and the
maintainer explicitly identified `/metadata` as the preferred endpoint in
#1203.

## Changes

The server information request now uses `/metadata`. The returned fields used
by GitLabForm (`version`, `revision`, and `enterprise`) and all subsequent
initialization behavior remain unchanged.

The acceptance-test edition fixture now uses the same endpoint, avoiding a
difference between production and test setup.

## Validation

- `.venv/bin/python -m pytest -q tests/unit/gitlab/test_core.py` — 8 passed
- `.venv/bin/python -m pytest -q tests/unit` — 239 passed
- `.venv/bin/python -m pytest -q --collect-only tests/acceptance/standard/test_running.py` — 4 tests collected
- `UV_CACHE_DIR=/private/tmp/gitlabform-uv-cache uv run --no-sync qa lint` — passed
- `UV_CACHE_DIR=/private/tmp/gitlabform-uv-cache uv lock --check` — passed
- `git diff --check origin/main...HEAD` — passed

The full acceptance suite requires a disposable GitLab instance and was not
executed locally. A repository-wide collection attempt also encounters the
existing duplicate `test_group_settings.py` module names across the Premium
and Ultimate suites, so collection was verified with a representative
standard suite instead.

## Compatibility and risk

No configuration or migration is required. GitLab documents `/metadata` as
available since GitLab 15.2, while GitLabForm currently warns for versions
earlier than 16. The response fields consumed by GitLabForm are unchanged.

This implements the `/metadata` migration subtask discussed in #1203.
